### PR TITLE
Change origin verification to use a regex

### DIFF
--- a/webauthn-server-core/src/main/java/com/yubico/webauthn/FinishAssertionSteps.java
+++ b/webauthn-server-core/src/main/java/com/yubico/webauthn/FinishAssertionSteps.java
@@ -45,6 +45,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import java.util.regex.Pattern;
 import lombok.Builder;
 import lombok.Value;
 import lombok.extern.slf4j.Slf4j;
@@ -375,7 +376,9 @@ final class FinishAssertionSteps {
             final String responseOrigin;
             responseOrigin = response.getResponse().getClientData().getOrigin();
 
-            if (origins.stream().noneMatch(o -> o.equals(responseOrigin))) {
+            if (origins.stream().noneMatch(allowedOrigin ->
+                    Pattern.compile("(https://)?(\\w+\\.)?" + allowedOrigin + "(:\\d+)?")
+                            .matcher(responseOrigin).matches())) {
                 throw new IllegalArgumentException("Incorrect origin: " + responseOrigin);
             }
         }

--- a/webauthn-server-core/src/main/java/com/yubico/webauthn/FinishRegistrationSteps.java
+++ b/webauthn-server-core/src/main/java/com/yubico/webauthn/FinishRegistrationSteps.java
@@ -48,6 +48,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import java.util.regex.Pattern;
 import lombok.Builder;
 import lombok.Value;
 import lombok.extern.slf4j.Slf4j;
@@ -214,7 +215,9 @@ final class FinishRegistrationSteps {
         @Override
         public void validate() {
             assure(
-                origins.stream().anyMatch(o -> o.equals(clientData.getOrigin())),
+                origins.stream().anyMatch(allowedOrigin ->
+                        Pattern.compile("(https://)?(\\w+\\.)?" + allowedOrigin + "(:\\d+)?")
+                                .matcher(clientData.getOrigin()).matches()),
                 "Incorrect origin: " + clientData.getOrigin()
             );
         }

--- a/webauthn-server-core/src/main/java/com/yubico/webauthn/RelyingParty.java
+++ b/webauthn-server-core/src/main/java/com/yubico/webauthn/RelyingParty.java
@@ -89,15 +89,11 @@ public class RelyingParty {
     private final RelyingPartyIdentity identity;
 
     /**
-     * The allowed origins that returned authenticator responses will be compared against.
+     * The allowed origins that returned authenticator responses will be compared against. Incoming origins can
+     * expand on the string with subdomains and a port number. This set should only contain FQDNs.
      *
      * <p>
-     * The default is the set containing only the string <code>"https://" + {@link #getIdentity()}.getId()</code>.
-     * </p>
-     *
-     * <p>
-     * A successful registration or authentication operation requires {@link CollectedClientData#getOrigin()} to exactly
-     * equal one of these values.
+     * The default is the set containing only the string <code>{@link #getIdentity()}.getId()</code>.
      * </p>
      *
      * @see #getIdentity()
@@ -265,7 +261,7 @@ public class RelyingParty {
         boolean validateSignatureCounter
     ) {
         this.identity = identity;
-        this.origins = origins != null ? origins : Collections.singleton("https://" + identity.getId());
+        this.origins = origins != null ? origins : Collections.singleton(identity.getId());
         this.credentialRepository = credentialRepository;
         this.appId = appId;
         this.attestationConveyancePreference = attestationConveyancePreference;


### PR DESCRIPTION
fixes #15 
fixes #34 

This will match all subdomains of the specified origins, as well as allow any port numbers to be present in the origin URI sent by the client (won't really happen outside of localhost).

I can cut the scope down to just the port numbers, since it's possible that someone might want to disallow specific (or all) subdomains, but I have a hard time coming up with a scenario that would require the functionality.

Let me know what you think @emlun.