### PR TITLE
Read all version info from manifest

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -74,6 +74,15 @@ task assembleJavadoc(type: Sync) {
   destinationDir = file("${rootProject.buildDir}/javadoc")
 }
 
+String getGitCommit() {
+  def proc = "git rev-parse HEAD".execute(null, projectDir)
+  proc.waitFor()
+  if (proc.exitValue() != 0) {
+    throw new RuntimeException("Failed to get git commit ID");
+  }
+  return proc.text.trim()
+}
+
 subprojects { project ->
 
   sourceCompatibility = 1.8

--- a/test-dependent-projects/java-dep-webauthn-server-attestation/build.gradle.kts
+++ b/test-dependent-projects/java-dep-webauthn-server-attestation/build.gradle.kts
@@ -4,5 +4,6 @@ plugins {
 
 dependencies {
     implementation(project(":webauthn-server-attestation"))
+    testImplementation("junit:junit:4.12")
 }
 

--- a/test-dependent-projects/java-dep-webauthn-server-attestation/src/test/java/com/yubico/webauthn/attestation/ManifestInfoTest.java
+++ b/test-dependent-projects/java-dep-webauthn-server-attestation/src/test/java/com/yubico/webauthn/attestation/ManifestInfoTest.java
@@ -32,4 +32,9 @@ public class ManifestInfoTest {
         assertEquals("Yubico", lookup("Implementation-Vendor"));
     }
 
+    @Test
+    public void customImplementationPropertiesAreSet() throws IOException {
+        assertTrue(lookup("Git-Commit").matches("^[a-f0-9]{40}$"));
+    }
+
 }

--- a/test-dependent-projects/java-dep-webauthn-server-attestation/src/test/java/com/yubico/webauthn/attestation/ManifestInfoTest.java
+++ b/test-dependent-projects/java-dep-webauthn-server-attestation/src/test/java/com/yubico/webauthn/attestation/ManifestInfoTest.java
@@ -1,0 +1,35 @@
+package com.yubico.webauthn.attestation;
+
+import java.io.IOException;
+import java.net.URL;
+import java.util.Enumeration;
+import java.util.NoSuchElementException;
+import java.util.jar.Manifest;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class ManifestInfoTest {
+
+    private static String lookup(String key) throws IOException {
+        final Enumeration<URL> resources = AttestationResolver.class.getClassLoader().getResources("META-INF/MANIFEST.MF");
+
+        while (resources.hasMoreElements()) {
+            final URL resource = resources.nextElement();
+            final Manifest manifest = new Manifest(resource.openStream());
+            if ("java-webauthn-server-attestation".equals(manifest.getMainAttributes().getValue("Implementation-Id"))) {
+                return manifest.getMainAttributes().getValue(key);
+            }
+        }
+        throw new NoSuchElementException("Could not find \"" + key + "\" in manifest.");
+    }
+
+    @Test
+    public void standardImplementationPropertiesAreSet() throws IOException {
+        assertTrue(lookup("Implementation-Title").contains("attestation"));
+        assertTrue(lookup("Implementation-Version").matches("^\\d+\\.\\d+\\.\\d+(-.*)?"));
+        assertEquals("Yubico", lookup("Implementation-Vendor"));
+    }
+
+}

--- a/test-dependent-projects/java-dep-webauthn-server-core/build.gradle.kts
+++ b/test-dependent-projects/java-dep-webauthn-server-core/build.gradle.kts
@@ -4,5 +4,6 @@ plugins {
 
 dependencies {
     implementation(project(":webauthn-server-core"))
+    testImplementation("junit:junit:4.12")
 }
 

--- a/test-dependent-projects/java-dep-webauthn-server-core/src/test/java/com/yubico/webauthn/meta/ManifestInfoTest.java
+++ b/test-dependent-projects/java-dep-webauthn-server-core/src/test/java/com/yubico/webauthn/meta/ManifestInfoTest.java
@@ -1,0 +1,53 @@
+package com.yubico.webauthn.meta;
+
+import com.yubico.webauthn.RelyingParty;
+import java.io.IOException;
+import java.net.URL;
+import java.time.LocalDate;
+import java.util.Enumeration;
+import java.util.NoSuchElementException;
+import java.util.jar.Manifest;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class ManifestInfoTest {
+
+    private static String lookup(String key) throws IOException {
+        final Enumeration<URL> resources = RelyingParty.class.getClassLoader().getResources("META-INF/MANIFEST.MF");
+
+        while (resources.hasMoreElements()) {
+            final URL resource = resources.nextElement();
+            final Manifest manifest = new Manifest(resource.openStream());
+            if ("java-webauthn-server".equals(manifest.getMainAttributes().getValue("Implementation-Id"))) {
+                return manifest.getMainAttributes().getValue(key);
+            }
+        }
+        throw new NoSuchElementException("Could not find \"" + key + "\" in manifest.");
+    }
+
+    @Test
+    public void standardSpecPropertiesAreSet() throws IOException {
+        assertTrue(lookup("Specification-Title").startsWith("Web Authentication"));
+        assertTrue(lookup("Specification-Version").startsWith("Level"));
+        assertEquals("World Wide Web Consortium", lookup("Specification-Vendor"));
+    }
+
+
+    @Test
+    public void customSpecPropertiesAreSet() throws IOException {
+        assertTrue(lookup("Specification-Url").startsWith("https://"));
+        assertTrue(lookup("Specification-Url-Latest").startsWith("https://"));
+        assertTrue(DocumentStatus.fromString(lookup("Specification-W3c-Status")).isPresent());
+        assertTrue(LocalDate.parse(lookup("Specification-Release-Date")).isAfter(LocalDate.of(2019, 3, 3)));
+    }
+
+    @Test
+    public void standardImplementationPropertiesAreSet() throws IOException {
+        assertTrue(lookup("Implementation-Title").contains("Web Authentication"));
+        assertTrue(lookup("Implementation-Version").matches("^\\d+\\.\\d+\\.\\d+(-.*)?"));
+        assertEquals("Yubico", lookup("Implementation-Vendor"));
+    }
+
+}

--- a/test-dependent-projects/java-dep-webauthn-server-core/src/test/java/com/yubico/webauthn/meta/ManifestInfoTest.java
+++ b/test-dependent-projects/java-dep-webauthn-server-core/src/test/java/com/yubico/webauthn/meta/ManifestInfoTest.java
@@ -50,4 +50,9 @@ public class ManifestInfoTest {
         assertEquals("Yubico", lookup("Implementation-Vendor"));
     }
 
+    @Test
+    public void customImplementationPropertiesAreSet() throws IOException {
+        assertTrue(lookup("Git-Commit").matches("^[a-f0-9]{40}$"));
+    }
+
 }

--- a/test-dependent-projects/java-dep-webauthn-server-core/src/test/java/com/yubico/webauthn/meta/VersionInfoTest.java
+++ b/test-dependent-projects/java-dep-webauthn-server-core/src/test/java/com/yubico/webauthn/meta/VersionInfoTest.java
@@ -28,6 +28,7 @@ public class VersionInfoTest {
         final Implementation impl = versionInfo.getImplementation();
         assertTrue(impl.getSourceCodeUrl().toExternalForm().startsWith("https://"));
         assertTrue(impl.getVersion().matches("^\\d+\\.\\d+\\.\\d+(-.*)?"));
+        assertTrue(impl.getGitCommit().matches("^[a-f0-9]{40}$"));
     }
 
     @Test

--- a/test-dependent-projects/java-dep-webauthn-server-core/src/test/java/com/yubico/webauthn/meta/VersionInfoTest.java
+++ b/test-dependent-projects/java-dep-webauthn-server-core/src/test/java/com/yubico/webauthn/meta/VersionInfoTest.java
@@ -1,0 +1,41 @@
+package com.yubico.webauthn.meta;
+
+import java.time.LocalDate;
+import org.junit.Test;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Since this depends on the manifest of the core jar, and the manifest is build by Gradle, this test is likely to fail
+ * when run in an IDE. It works as expected when run via Gradle.
+ */
+public class VersionInfoTest {
+
+    final VersionInfo versionInfo = VersionInfo.getInstance();
+
+    @Test
+    public void specPropertiesAreSet() {
+        final Specification spec = versionInfo.getSpecification();
+        assertTrue(spec.getLatestVersionUrl().toExternalForm().startsWith("https://"));
+        assertTrue(spec.getUrl().toExternalForm().startsWith("https://"));
+        assertTrue(spec.getReleaseDate().isAfter(LocalDate.of(2019, 3, 3)));
+        assertNotNull(spec.getStatus());
+    }
+
+    @Test
+    public void implementationPropertiesAreSet() {
+        final Implementation impl = versionInfo.getImplementation();
+        assertTrue(impl.getSourceCodeUrl().toExternalForm().startsWith("https://"));
+        assertTrue(impl.getVersion().get().matches("^\\d+\\.\\d+\\.\\d+(-.*)?"));
+    }
+
+    @Test
+    public void majorVersionIsAtLeast1() {
+        final String version = versionInfo.getImplementation().getVersion().get();
+        String[] splits = version.split("\\.");
+        final int majorVersion = Integer.parseInt(splits[0]);
+        assertTrue(majorVersion >= 1);
+    }
+
+}

--- a/test-dependent-projects/java-dep-webauthn-server-core/src/test/java/com/yubico/webauthn/meta/VersionInfoTest.java
+++ b/test-dependent-projects/java-dep-webauthn-server-core/src/test/java/com/yubico/webauthn/meta/VersionInfoTest.java
@@ -27,12 +27,12 @@ public class VersionInfoTest {
     public void implementationPropertiesAreSet() {
         final Implementation impl = versionInfo.getImplementation();
         assertTrue(impl.getSourceCodeUrl().toExternalForm().startsWith("https://"));
-        assertTrue(impl.getVersion().get().matches("^\\d+\\.\\d+\\.\\d+(-.*)?"));
+        assertTrue(impl.getVersion().matches("^\\d+\\.\\d+\\.\\d+(-.*)?"));
     }
 
     @Test
     public void majorVersionIsAtLeast1() {
-        final String version = versionInfo.getImplementation().getVersion().get();
+        final String version = versionInfo.getImplementation().getVersion();
         String[] splits = version.split("\\.");
         final int majorVersion = Integer.parseInt(splits[0]);
         assertTrue(majorVersion >= 1);

--- a/webauthn-server-attestation/build.gradle
+++ b/webauthn-server-attestation/build.gradle
@@ -46,6 +46,7 @@ jar {
       'Implementation-Title': project.description,
       'Implementation-Version': project.version,
       'Implementation-Vendor': 'Yubico',
+      'Git-Commit': getGitCommit(),
     ])
   }
 }

--- a/webauthn-server-core/build.gradle
+++ b/webauthn-server-core/build.gradle
@@ -55,6 +55,7 @@ jar {
       'Implementation-Version': project.version,
       'Implementation-Vendor': 'Yubico',
       'Implementation-Source-Url': 'https://github.com/Yubico/java-webauthn-server',
+      'Git-Commit': getGitCommit(),
     ])
   }
 }

--- a/webauthn-server-core/build.gradle
+++ b/webauthn-server-core/build.gradle
@@ -44,10 +44,17 @@ jar {
       'Specification-Title': 'Web Authentication: An API for accessing Public Key Credentials',
       'Specification-Version': 'Level 1 Recommendation 2019-03-04',
       'Specification-Vendor': 'World Wide Web Consortium',
+
+      'Specification-Url': 'https://www.w3.org/TR/2019/REC-webauthn-1-20190304/',
+      'Specification-Url-Latest': 'https://www.w3.org/TR/webauthn/',
+      'Specification-W3c-Status': 'recommendation',
+      'Specification-Release-Date': '2019-03-04',
+
       'Implementation-Id': 'java-webauthn-server',
       'Implementation-Title': 'Yubico Web Authentication server library',
       'Implementation-Version': project.version,
       'Implementation-Vendor': 'Yubico',
+      'Implementation-Source-Url': 'https://github.com/Yubico/java-webauthn-server',
     ])
   }
 }

--- a/webauthn-server-core/src/main/java/com/yubico/webauthn/meta/DocumentStatus.java
+++ b/webauthn-server-core/src/main/java/com/yubico/webauthn/meta/DocumentStatus.java
@@ -27,7 +27,10 @@ package com.yubico.webauthn.meta;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.yubico.internal.util.json.JsonStringSerializable;
 import com.yubico.internal.util.json.JsonStringSerializer;
+import java.util.Optional;
+import java.util.stream.Stream;
 import lombok.AllArgsConstructor;
+import lombok.NonNull;
 
 /**
  * A representation of Web Authentication specification document statuses.
@@ -61,6 +64,10 @@ public enum DocumentStatus implements JsonStringSerializable {
     RECOMMENDATION("recommendation");
 
     private final String id;
+
+    static Optional<DocumentStatus> fromString(@NonNull String id) {
+        return Stream.of(values()).filter(v -> v.id.equals(id)).findAny();
+    }
 
     /**
      * Used by JSON serializer.

--- a/webauthn-server-core/src/main/java/com/yubico/webauthn/meta/Implementation.java
+++ b/webauthn-server-core/src/main/java/com/yubico/webauthn/meta/Implementation.java
@@ -51,4 +51,10 @@ public class Implementation {
     @NonNull
     private final URL sourceCodeUrl;
 
+    /**
+     * The commit ID of the source code the library was built from, if known.
+     */
+    @NonNull
+    private final String gitCommit;
+
 }

--- a/webauthn-server-core/src/main/java/com/yubico/webauthn/meta/Implementation.java
+++ b/webauthn-server-core/src/main/java/com/yubico/webauthn/meta/Implementation.java
@@ -42,6 +42,7 @@ public class Implementation {
     /**
      * The version number of this release of the library.
      */
+    @NonNull
     private final String version;
 
     /**
@@ -49,9 +50,5 @@ public class Implementation {
      */
     @NonNull
     private final URL sourceCodeUrl;
-
-    public Optional<String> getVersion() {
-        return Optional.ofNullable(version);
-    }
 
 }

--- a/webauthn-server-core/src/main/java/com/yubico/webauthn/meta/VersionInfo.java
+++ b/webauthn-server-core/src/main/java/com/yubico/webauthn/meta/VersionInfo.java
@@ -74,7 +74,8 @@ public class VersionInfo {
      */
     private final Implementation implementation = new Implementation(
         findValueInManifest("Implementation-Version"),
-        new URL(findValueInManifest("Implementation-Source-Url"))
+        new URL(findValueInManifest("Implementation-Source-Url")),
+        findValueInManifest("Git-Commit")
     );
 
     private VersionInfo() throws IOException {

--- a/webauthn-server-core/src/main/java/com/yubico/webauthn/meta/VersionInfo.java
+++ b/webauthn-server-core/src/main/java/com/yubico/webauthn/meta/VersionInfo.java
@@ -29,10 +29,9 @@ import java.io.IOException;
 import java.net.URL;
 import java.time.LocalDate;
 import java.util.Enumeration;
+import java.util.NoSuchElementException;
 import java.util.Optional;
 import java.util.jar.Manifest;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
 import lombok.Value;
 import lombok.extern.slf4j.Slf4j;
 
@@ -64,35 +63,34 @@ public class VersionInfo {
      * Represents the specification this implementation is based on
      */
     private final Specification specification = Specification.builder()
-        .url(new URL("https://www.w3.org/TR/2019/REC-webauthn-1-20190304/"))
-        .latestVersionUrl(new URL("https://www.w3.org/TR/webauthn/"))
-        .status(DocumentStatus.RECOMMENDATION)
-        .releaseDate(LocalDate.parse("2019-03-04"))
+        .url(new URL(findValueInManifest("Specification-Url")))
+        .latestVersionUrl(new URL(findValueInManifest("Specification-Url-Latest")))
+        .status(DocumentStatus.fromString(findValueInManifest("Specification-W3c-Status")).get())
+        .releaseDate(LocalDate.parse(findValueInManifest("Specification-Release-Date")))
         .build();
 
     /**
      * Description of this version of this library
      */
     private final Implementation implementation = new Implementation(
-        findImplementationVersionInManifest().orElse(null),
-        new URL("https://github.com/Yubico/java-webauthn-server")
+        findValueInManifest("Implementation-Version"),
+        new URL(findValueInManifest("Implementation-Source-Url"))
     );
 
     private VersionInfo() throws IOException {
     }
 
-    private Optional<String> findImplementationVersionInManifest() throws IOException {
+    private String findValueInManifest(String key) throws IOException {
         final Enumeration<URL> resources = getClass().getClassLoader().getResources("META-INF/MANIFEST.MF");
 
         while (resources.hasMoreElements()) {
             final URL resource = resources.nextElement();
             final Manifest manifest = new Manifest(resource.openStream());
             if ("java-webauthn-server".equals(manifest.getMainAttributes().getValue("Implementation-Id"))) {
-                return Optional.ofNullable(manifest.getMainAttributes().getValue("Implementation-Version"));
+                return manifest.getMainAttributes().getValue(key);
             }
         }
-
-        return Optional.empty();
+        throw new NoSuchElementException("Could not find \"" + key + "\" in manifest.");
     }
 
 }


### PR DESCRIPTION
The class `VersionInfo` contains a declaration of the version of the library, and some references to the version of the spec that the implementation is based on. This version info is currently duplicated between the manifest and the hard-coded literals in `VersionInfo`; these changes make the manifest the single source of truth and also adds the Git commit ID to the set of version info.