### PR TITLE
Make Git not required to build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -121,9 +121,13 @@ String getGitCommit() {
   def proc = "git rev-parse HEAD".execute(null, projectDir)
   proc.waitFor()
   if (proc.exitValue() != 0) {
-    throw new RuntimeException("Failed to get git commit ID");
+    return null
   }
   return proc.text.trim()
+}
+
+String getGitCommitOrUnknown() {
+  return getGitCommit() ?: 'UNKNOWN'
 }
 
 subprojects { project ->
@@ -211,6 +215,10 @@ subprojects { project ->
 
     apply plugin: 'maven-publish'
     apply plugin: 'signing'
+
+    if (getGitCommit() == null) {
+      throw new RuntimeException("Failed to get git commit ID");
+    }
 
     publishing {
       publications {

--- a/test-dependent-projects/java-dep-webauthn-server-attestation/src/test/java/com/yubico/webauthn/attestation/ManifestInfoTest.java
+++ b/test-dependent-projects/java-dep-webauthn-server-attestation/src/test/java/com/yubico/webauthn/attestation/ManifestInfoTest.java
@@ -36,6 +36,7 @@ public class ManifestInfoTest {
 
   @Test
   public void customImplementationPropertiesAreSet() throws IOException {
-    assertTrue(lookup("Git-Commit").matches("^[a-f0-9]{40}$"));
+    assertTrue(
+        lookup("Git-Commit").matches("^[a-f0-9]{40}$") || lookup("Git-Commit").equals("UNKNOWN"));
   }
 }

--- a/test-dependent-projects/java-dep-webauthn-server-core/src/test/java/com/yubico/webauthn/meta/ManifestInfoTest.java
+++ b/test-dependent-projects/java-dep-webauthn-server-core/src/test/java/com/yubico/webauthn/meta/ManifestInfoTest.java
@@ -54,6 +54,7 @@ public class ManifestInfoTest {
 
   @Test
   public void customImplementationPropertiesAreSet() throws IOException {
-    assertTrue(lookup("Git-Commit").matches("^[a-f0-9]{40}$"));
+    assertTrue(
+        lookup("Git-Commit").matches("^[a-f0-9]{40}$") || lookup("Git-Commit").equals("UNKNOWN"));
   }
 }

--- a/test-dependent-projects/java-dep-webauthn-server-core/src/test/java/com/yubico/webauthn/meta/VersionInfoTest.java
+++ b/test-dependent-projects/java-dep-webauthn-server-core/src/test/java/com/yubico/webauthn/meta/VersionInfoTest.java
@@ -28,14 +28,17 @@ public class VersionInfoTest {
     final Implementation impl = versionInfo.getImplementation();
     assertTrue(impl.getSourceCodeUrl().toExternalForm().startsWith("https://"));
     assertTrue(impl.getVersion().matches("^\\d+\\.\\d+\\.\\d+(-.*)?"));
-    assertTrue(impl.getGitCommit().matches("^[a-f0-9]{40}$"));
+    assertTrue(
+        impl.getGitCommit().matches("^[a-f0-9]{40}$") || impl.getGitCommit().equals("UNKNOWN"));
   }
 
   @Test
-  public void majorVersionIsAtLeast1() {
+  public void majorVersionIsUnknownOrAtLeast1() {
     final String version = versionInfo.getImplementation().getVersion();
-    String[] splits = version.split("\\.");
-    final int majorVersion = Integer.parseInt(splits[0]);
-    assertTrue(majorVersion >= 1);
+    if (!"0.1.0-SNAPSHOT".equals(version)) {
+      String[] splits = version.split("\\.");
+      final int majorVersion = Integer.parseInt(splits[0]);
+      assertTrue(majorVersion >= 1);
+    }
   }
 }

--- a/webauthn-server-attestation/build.gradle
+++ b/webauthn-server-attestation/build.gradle
@@ -58,7 +58,7 @@ jar {
       'Implementation-Title': project.description,
       'Implementation-Version': project.version,
       'Implementation-Vendor': 'Yubico',
-      'Git-Commit': getGitCommit(),
+      'Git-Commit': getGitCommitOrUnknown(),
     ])
   }
 }

--- a/webauthn-server-core-bundle/build.gradle
+++ b/webauthn-server-core-bundle/build.gradle
@@ -27,7 +27,7 @@ jar {
       'Implementation-Version': project.version,
       'Implementation-Vendor': 'Yubico',
       'Implementation-Source-Url': 'https://github.com/Yubico/java-webauthn-server',
-      'Git-Commit': getGitCommit(),
+      'Git-Commit': getGitCommitOrUnknown(),
     ])
   }
 }

--- a/webauthn-server-core/build.gradle
+++ b/webauthn-server-core/build.gradle
@@ -67,7 +67,7 @@ jar {
       'Implementation-Version': project.version,
       'Implementation-Vendor': 'Yubico',
       'Implementation-Source-Url': 'https://github.com/Yubico/java-webauthn-server',
-      'Git-Commit': getGitCommit(),
+      'Git-Commit': getGitCommitOrUnknown(),
     ])
   }
 }


### PR DESCRIPTION
Fixes #116.

A Git repository will still be required to get accurate version numbers and to publish artifacts, but the project can now be built and pass the tests without a local Git repository.

Pinging @dainnilsson for review just for the light modifications to a few of the tests. Seem reasonable? These tests are for the in-library metadata declaration, which includes the library version among other things. That's all separate from the main functional parts of the library.