### PR TITLE
Don't run CodeQL on push event for Dependabot branches

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -2,6 +2,7 @@ name: "Code scanning - action"
 
 on:
   push:
+    branches-ignore: 'dependabot/**'
   pull_request:
   schedule:
     - cron: '0 12 * * 2'


### PR DESCRIPTION
Fixes:

```
Error: Workflows triggered by Dependabot on the "push" event run with read-only access. Uploading Code Scanning results requires write access. To use Code Scanning with Dependabot, please ensure you are using the "pull_request" event for this workflow and avoid triggering on the "push" event for Dependabot branches. See https://docs.github.com/en/code-security/secure-coding/configuring-code-scanning#scanning-on-push for more information on how to configure these events.
```

See for example: https://github.com/Yubico/java-webauthn-server/pull/119/checks?check_run_id=2397223687#step:4:56