### PR TITLE
Use Java 16 instead of 15 in GitHub Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: [8, 11, 15]
+        java: [8, 11, 16]
 
     steps:
     - name: Check out code


### PR DESCRIPTION
Since Java 15 is now past end-of-life.