### PR TITLE
Fixing some README Javascript Typo's

### DIFF
--- a/README
+++ b/README
@@ -210,14 +210,14 @@ fetch(/* ... */)                    // Make the call that returns the credential
     publicKey: {
       ...credentialCreateJson.publicKey,
 
-      challenge: base64urlToUint8Array(credentialCreateJson.publicKey.challenge),
+      challenge: base64urlToUint8array(credentialCreateJson.publicKey.challenge),
       user: {
         ...credentialCreateJson.publicKey.user,
-        id: base64urlToUint8Array(credentialCreateJson.publicKey.user.id),
+        id: base64urlToUint8array(credentialCreateJson.publicKey.user.id),
       },
       excludeCredentials: credentialCreateJson.publicKey.excludeCredentials.map(credential => ({
         ...credential,
-        id: base64urlToUint8Array(credential.id),
+        id: base64urlToUint8array(credential.id),
       })),
 
       // Warning: Extension inputs could also contain binary data that needs encoding
@@ -230,13 +230,13 @@ fetch(/* ... */)                    // Make the call that returns the credential
     type: publicKeyCredential.type,
     id: publicKeyCredential.id,
     response: {
-      attestationObject: uint8arrayToBase64url(response.response.attestationObject),
-      clientDataJSON: uint8arrayToBase64url(response.response.clientDataJSON),
-      transports: response.response.getTransports() || [],
+      attestationObject: uint8arrayToBase64url(publicKeyCredential.response.attestationObject),
+      clientDataJSON: uint8arrayToBase64url(publicKeyCredential.response.clientDataJSON),
+      transports: publicKeyCredential.response.getTransports() || [],
     },
 
     // Warning: Client extension results could also contain binary data that needs encoding
-    clientExtensionResults: response.getClientExtensionResults(),
+    clientExtensionResults: publicKeyCredential.getClientExtensionResults(),
   }))
   .then(encodedResult =>
     fetch(/* ... */));              // Return encoded PublicKeyCredential to server
@@ -324,10 +324,10 @@ fetch(/* ... */)                    // Make the call that returns the credential
       allowCredentials: credentialGetJson.publicKey.allowCredentials
         && credentialGetJson.publicKey.allowCredentials.map(credential => ({
           ...credential,
-          id: base64urlToUint8Array(credential.id),
+          id: base64urlToUint8array(credential.id),
         })),
 
-      challenge: base64urlToUint8Array(credentialGetJson.publicKey.challenge),
+      challenge: base64urlToUint8array(credentialGetJson.publicKey.challenge),
 
       // Warning: Extension inputs could also contain binary data that needs encoding
       extensions: credentialGetJson.publicKey.extensions,
@@ -339,14 +339,14 @@ fetch(/* ... */)                    // Make the call that returns the credential
     type: publicKeyCredential.type,
     id: publicKeyCredential.id,
     response: {
-      authenticatorData: uint8arrayToBase64url(response.response.authenticatorData),
-      clientDataJSON: uint8arrayToBase64url(response.response.clientDataJSON),
-      signature: uint8arrayToBase64url(response.response.signature),
-      userHandle: response.response.userHandle && uint8arrayToBase64url(response.response.userHandle),
+      authenticatorData: uint8arrayToBase64url(publicKeyCredential.response.authenticatorData),
+      clientDataJSON: uint8arrayToBase64url(publicKeyCredential.response.clientDataJSON),
+      signature: uint8arrayToBase64url(publicKeyCredential.response.signature),
+      userHandle: publicKeyCredential.response.userHandle && uint8arrayToBase64url(publicKeyCredential.response.userHandle),
     },
 
     // Warning: Client extension results could also contain binary data that needs encoding
-    clientExtensionResults: response.getClientExtensionResults(),
+    clientExtensionResults: publicKeyCredential.getClientExtensionResults(),
   }))
   .then(encodedResult =>
     fetch(/* ... */));              // Return encoded PublicKeyCredential to server

--- a/README
+++ b/README
@@ -202,7 +202,11 @@ function base64urlToUint8array(base64Bytes) {
   return base64js.toByteArray((base64Bytes + padding).replace(/\//g, "_").replace(/\+/g, "-"));
 }
 function uint8arrayToBase64url(bytes) {
-  return base64js.fromByteArray(bytes).replace(/\+/g, "-").replace(/\//g, "_").replace(/=/g, "");
+  if (bytes instanceof Uint8Array) {
+    return base64js.fromByteArray(bytes).replace(/\+/g, "-").replace(/\//g, "_").replace(/=/g, "");
+  } else {
+    return uint8arrayToBase64url(new Uint8Array(bytes));
+  }
 }
 
 fetch(/* ... */)                    // Make the call that returns the credentialCreateJson above
@@ -314,7 +318,11 @@ function base64urlToUint8array(base64Bytes) {
   return base64js.toByteArray((base64Bytes + padding).replace(/\//g, "_").replace(/\+/g, "-"));
 }
 function uint8arrayToBase64url(bytes) {
-  return base64js.fromByteArray(bytes).replace(/\+/g, "-").replace(/\//g, "_").replace(/=/g, "");
+  if (bytes instanceof Uint8Array) {
+    return base64js.fromByteArray(bytes).replace(/\+/g, "-").replace(/\//g, "_").replace(/=/g, "");
+  } else {
+    return uint8arrayToBase64url(new Uint8Array(bytes));
+  }
 }
 
 fetch(/* ... */)                    // Make the call that returns the credentialGetJson above

--- a/README
+++ b/README
@@ -236,7 +236,9 @@ fetch(/* ... */)                    // Make the call that returns the credential
     response: {
       attestationObject: uint8arrayToBase64url(publicKeyCredential.response.attestationObject),
       clientDataJSON: uint8arrayToBase64url(publicKeyCredential.response.clientDataJSON),
-      transports: publicKeyCredential.response.getTransports() || [],
+
+      // Attempt to read transports, but recover gracefully if not supported by the browser
+      transports: publicKeyCredential.response.getTransports && publicKeyCredential.response.getTransports() || [],
     },
 
     // Warning: Client extension results could also contain binary data that needs encoding

--- a/webauthn-server-demo/src/main/webapp/js/webauthn.js
+++ b/webauthn-server-demo/src/main/webapp/js/webauthn.js
@@ -141,7 +141,7 @@
           response: {
             attestationObject: base64url.fromByteArray(response.response.attestationObject),
             clientDataJSON: base64url.fromByteArray(response.response.clientDataJSON),
-            transports: response.response.getTransports() || [],
+            transports: response.response.getTransports && response.response.getTransports() || [],
           },
           clientExtensionResults,
         };


### PR DESCRIPTION
Fixing a few typos in the Javascript code README samples.
- There is a case-sensitivity typo in the `base64urlToUint8Array` method name. (`base64urlToUint8Array` vs `base64urlToUint8array`)
- We are referencing an undefined variable (`response`)