### PR TITLE
Fix format violations

### DIFF
--- a/webauthn-server-demo/src/main/java/demo/webauthn/InMemoryRegistrationStorage.java
+++ b/webauthn-server-demo/src/main/java/demo/webauthn/InMemoryRegistrationStorage.java
@@ -166,7 +166,9 @@ public class InMemoryRegistrationStorage implements CredentialRepository {
     regs.remove(registration);
     regs.add(
         registration.withCredential(
-            registration.getCredential().toBuilder()
+            registration
+                .getCredential()
+                .toBuilder()
                 .signatureCount(result.getSignatureCount())
                 .build()));
   }


### PR DESCRIPTION
Fixes the following format violations:
```
> Task :webauthn-server-demo:spotlessJavaCheck FAILED

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':webauthn-server-demo:spotlessJavaCheck'.
> The following files had format violations:
      src/main/java/demo/webauthn/InMemoryRegistrationStorage.java
          @@ -166,7 +166,9 @@
           ····regs.remove(registration);
           ····regs.add(
           ········registration.withCredential(
          -············registration.getCredential().toBuilder()
          +············registration
          +················.getCredential()
          +················.toBuilder()
           ················.signatureCount(result.getSignatureCount())
           ················.build()));
           ··}
```