### PR TITLE
Update jackson deps to the latest version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,7 +46,13 @@ wrapper {
 dependencies {
   constraints {
     api('com.augustcellars.cose:cose-java:[1.0.0,2)')
-    api('com.fasterxml.jackson:jackson-bom:2.13.2.20220324')
+    api('com.fasterxml.jackson:jackson-bom') {
+      version {
+        strictly '[2.13.2.1,3)'
+        reject '2.13.2.1'
+      }
+      because 'jackson-databind 2.13.2.1 references nonexistent BOM'
+    }
     api('com.fasterxml.jackson.core:jackson-databind:[2.13.2.1,3)')
     api('com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:[2.13.2,3)')
     api('com.fasterxml.jackson.datatype:jackson-datatype-jdk8:[2.13.2,3)')

--- a/build.gradle
+++ b/build.gradle
@@ -46,9 +46,10 @@ wrapper {
 dependencies {
   constraints {
     api('com.augustcellars.cose:cose-java:[1.0.0,2)')
-    api('com.fasterxml.jackson.core:jackson-databind:[2.11.0,3)')
-    api('com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:[2.11.0,3)')
-    api('com.fasterxml.jackson.datatype:jackson-datatype-jdk8:[2.11.0,3)')
+    api('com.fasterxml.jackson:jackson-bom:2.13.2.20220324')
+    api('com.fasterxml.jackson.core:jackson-databind:[2.13.2.1,3)')
+    api('com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:[2.13.2,3)')
+    api('com.fasterxml.jackson.datatype:jackson-datatype-jdk8:[2.13.2,3)')
     api('com.google.guava:guava:[24.1.1,31)')
     api('com.upokecenter:cbor:[4.5.1,5)')
     api('javax.ws.rs:javax.ws.rs-api:[2.1,3)')


### PR DESCRIPTION
Update jackson-databind to 2.13.2.1 as it fixes [CVE-2020-36518](https://nvd.nist.gov/vuln/detail/CVE-2020-36518). For this version of jackson-databind it was necessary to use a different bom - see https://github.com/FasterXML/jackson-databind/issues/3428

The jackson-databind issue describing the CVE is here: https://github.com/FasterXML/jackson-databind/issues/2816