### PR TITLE
Make dependabot ignore patch version updates of spotless-plugin-gradle

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,3 +6,8 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+
+    ignore:
+      # Spotless patch updates are too noisy
+      - dependency-name: "spotless-plugin-gradle"
+        update-types: ["version-update:semver-patch"]


### PR DESCRIPTION
Patch-version updates of this plugin are a bit too noisy in my opinion.