### PR TITLE
Grant security-events: write permission to CodeQL workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,6 +55,10 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ always() && github.event_name == 'pull_request' }}
 
+    permissions:
+      checks: write
+      issues: write
+
     steps:
     - name: Download artifacts
       uses: actions/download-artifact@v3

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -16,6 +16,9 @@ jobs:
 
     runs-on: ubuntu-latest
 
+    permissions:
+      security-events: write
+
     steps:
     - name: Checkout repository
       uses: actions/checkout@v3


### PR DESCRIPTION
Ping @Yubico/prodsec just for visibility. In working on #201 I reduced the default workflow permissions from read/write to readonly, which is probably why this is needed now.