### PR TITLE
Update README for demo server

### DIFF
--- a/webauthn-server-demo/README
+++ b/webauthn-server-demo/README
@@ -152,3 +152,5 @@ correct environment.
     https://www.w3.org/TR/webauthn/#dom-publickeycredentialentity-name[RP name]
     the server will report. Example: `YUBICO_WEBAUTHN_RP_ID='Yubico Web
     Authentication demo'`
+
+  - `YUBICO_WEBAUTHN_U2F_APPID`: The https://developers.yubico.com/U2F/App_ID.html[U2F App ID] (single-facet). Example: `YUBICO_WEBAUTHN_U2F_APPID=https://demo.yubico.com:8443`. If not specified, defaults to https://localhost:8443.


### PR DESCRIPTION
The README for the demo server is not mentioning the `YUBICO_WEBAUTHN_U2F_APPID` envvar, which will cause domain-related errors, if not set. Fixed by adding short explanation on that envvar.