### PR TITLE
Automate signature upload step in release procedure

### DIFF
--- a/.github/workflows/release-verify-signatures.yml
+++ b/.github/workflows/release-verify-signatures.yml
@@ -2,7 +2,7 @@ name: Reproducible binary
 
 on:
   release:
-    types: [published, created, edited, prereleased]
+    types: [published, edited]
 
 jobs:
   verify:

--- a/.github/workflows/release-verify-signatures.yml
+++ b/.github/workflows/release-verify-signatures.yml
@@ -18,7 +18,7 @@ jobs:
     - name: check out code
       uses: actions/checkout@v3
       with:
-        ref: ${{ github.ref }}
+        ref: ${{ github.ref_name }}
 
     - name: Set up JDK
       uses: actions/setup-java@v3
@@ -36,20 +36,16 @@ jobs:
 
     - name: Verify signatures from GitHub release
       run: |
-        export TAGNAME=${GITHUB_REF#refs/tags/}
+        wget https://github.com/${GITHUB_REPOSITORY}/releases/download/${{ github.ref_name }}/webauthn-server-attestation-${{ github.ref_name }}.jar.asc
+        wget https://github.com/${GITHUB_REPOSITORY}/releases/download/${{ github.ref_name }}/webauthn-server-core-${{ github.ref_name }}.jar.asc
 
-        wget https://github.com/${GITHUB_REPOSITORY}/releases/download/${TAGNAME}/webauthn-server-attestation-${TAGNAME}.jar.asc
-        wget https://github.com/${GITHUB_REPOSITORY}/releases/download/${TAGNAME}/webauthn-server-core-${TAGNAME}.jar.asc
-
-        gpg --no-default-keyring --keyring yubico --verify webauthn-server-attestation-${TAGNAME}.jar.asc webauthn-server-attestation/build/libs/webauthn-server-attestation-${TAGNAME}.jar
-        gpg --no-default-keyring --keyring yubico --verify webauthn-server-core-${TAGNAME}.jar.asc webauthn-server-core/build/libs/webauthn-server-core-${TAGNAME}.jar
+        gpg --no-default-keyring --keyring yubico --verify webauthn-server-attestation-${{ github.ref_name }}.jar.asc webauthn-server-attestation/build/libs/webauthn-server-attestation-${{ github.ref_name }}.jar
+        gpg --no-default-keyring --keyring yubico --verify webauthn-server-core-${{ github.ref_name }}.jar.asc webauthn-server-core/build/libs/webauthn-server-core-${{ github.ref_name }}.jar
 
     - name: Verify signatures from Maven Central
       run: |
-        export TAGNAME=${GITHUB_REF#refs/tags/}
+        wget -O webauthn-server-core-${{ github.ref_name }}.jar.mavencentral.asc https://repo1.maven.org/maven2/com/yubico/webauthn-server-core/${{ github.ref_name }}/webauthn-server-core-${{ github.ref_name }}.jar.asc
+        wget -O webauthn-server-attestation-${{ github.ref_name }}.jar.mavencentral.asc https://repo1.maven.org/maven2/com/yubico/webauthn-server-attestation/${{ github.ref_name }}/webauthn-server-attestation-${{ github.ref_name }}.jar.asc
 
-        wget -O webauthn-server-core-${TAGNAME}.jar.mavencentral.asc https://repo1.maven.org/maven2/com/yubico/webauthn-server-core/${TAGNAME}/webauthn-server-core-${TAGNAME}.jar.asc
-        wget -O webauthn-server-attestation-${TAGNAME}.jar.mavencentral.asc https://repo1.maven.org/maven2/com/yubico/webauthn-server-attestation/${TAGNAME}/webauthn-server-attestation-${TAGNAME}.jar.asc
-
-        gpg --no-default-keyring --keyring yubico --verify webauthn-server-attestation-${TAGNAME}.jar.mavencentral.asc webauthn-server-attestation/build/libs/webauthn-server-attestation-${TAGNAME}.jar
-        gpg --no-default-keyring --keyring yubico --verify webauthn-server-core-${TAGNAME}.jar.mavencentral.asc webauthn-server-core/build/libs/webauthn-server-core-${TAGNAME}.jar
+        gpg --no-default-keyring --keyring yubico --verify webauthn-server-attestation-${{ github.ref_name }}.jar.mavencentral.asc webauthn-server-attestation/build/libs/webauthn-server-attestation-${{ github.ref_name }}.jar
+        gpg --no-default-keyring --keyring yubico --verify webauthn-server-core-${{ github.ref_name }}.jar.mavencentral.asc webauthn-server-core/build/libs/webauthn-server-core-${{ github.ref_name }}.jar

--- a/.github/workflows/release-verify-signatures.yml
+++ b/.github/workflows/release-verify-signatures.yml
@@ -32,20 +32,20 @@ jobs:
         ./gradlew jar
 
     - name: Fetch keys
-      run: gpg --no-default-keyring --keyring yubico --keyserver hkps://keys.openpgp.org --recv-keys 57A9DEED4C6D962A923BB691816F3ED99921835E
+      run: gpg --no-default-keyring --keyring ./yubico.keyring --keyserver hkps://keys.openpgp.org --recv-keys 57A9DEED4C6D962A923BB691816F3ED99921835E
 
     - name: Verify signatures from GitHub release
       run: |
         wget https://github.com/${GITHUB_REPOSITORY}/releases/download/${{ github.ref_name }}/webauthn-server-attestation-${{ github.ref_name }}.jar.asc
         wget https://github.com/${GITHUB_REPOSITORY}/releases/download/${{ github.ref_name }}/webauthn-server-core-${{ github.ref_name }}.jar.asc
 
-        gpg --no-default-keyring --keyring yubico --verify webauthn-server-attestation-${{ github.ref_name }}.jar.asc webauthn-server-attestation/build/libs/webauthn-server-attestation-${{ github.ref_name }}.jar
-        gpg --no-default-keyring --keyring yubico --verify webauthn-server-core-${{ github.ref_name }}.jar.asc webauthn-server-core/build/libs/webauthn-server-core-${{ github.ref_name }}.jar
+        gpg --no-default-keyring --keyring ./yubico.keyring --verify webauthn-server-attestation-${{ github.ref_name }}.jar.asc webauthn-server-attestation/build/libs/webauthn-server-attestation-${{ github.ref_name }}.jar
+        gpg --no-default-keyring --keyring ./yubico.keyring --verify webauthn-server-core-${{ github.ref_name }}.jar.asc webauthn-server-core/build/libs/webauthn-server-core-${{ github.ref_name }}.jar
 
     - name: Verify signatures from Maven Central
       run: |
         wget -O webauthn-server-core-${{ github.ref_name }}.jar.mavencentral.asc https://repo1.maven.org/maven2/com/yubico/webauthn-server-core/${{ github.ref_name }}/webauthn-server-core-${{ github.ref_name }}.jar.asc
         wget -O webauthn-server-attestation-${{ github.ref_name }}.jar.mavencentral.asc https://repo1.maven.org/maven2/com/yubico/webauthn-server-attestation/${{ github.ref_name }}/webauthn-server-attestation-${{ github.ref_name }}.jar.asc
 
-        gpg --no-default-keyring --keyring yubico --verify webauthn-server-attestation-${{ github.ref_name }}.jar.mavencentral.asc webauthn-server-attestation/build/libs/webauthn-server-attestation-${{ github.ref_name }}.jar
-        gpg --no-default-keyring --keyring yubico --verify webauthn-server-core-${{ github.ref_name }}.jar.mavencentral.asc webauthn-server-core/build/libs/webauthn-server-core-${{ github.ref_name }}.jar
+        gpg --no-default-keyring --keyring ./yubico.keyring --verify webauthn-server-attestation-${{ github.ref_name }}.jar.mavencentral.asc webauthn-server-attestation/build/libs/webauthn-server-attestation-${{ github.ref_name }}.jar
+        gpg --no-default-keyring --keyring ./yubico.keyring --verify webauthn-server-core-${{ github.ref_name }}.jar.mavencentral.asc webauthn-server-core/build/libs/webauthn-server-core-${{ github.ref_name }}.jar

--- a/.github/workflows/release-verify-signatures.yml
+++ b/.github/workflows/release-verify-signatures.yml
@@ -1,14 +1,42 @@
 name: Reproducible binary
 
+# This workflow waits for release signatures to appear on Maven Central,
+# then rebuilds the artifacts and verifies them against those signatures,
+# and finally uploads the signatures to the GitHub release.
+
 on:
   release:
     types: [published, edited]
 
 jobs:
+  download:
+    name: Download keys and signatures
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Fetch keys
+      run: gpg --no-default-keyring --keyring ./yubico.keyring --keyserver hkps://keys.openpgp.org --recv-keys 57A9DEED4C6D962A923BB691816F3ED99921835E
+
+    - name: Download signatures from Maven Central
+      timeout-minutes: 60
+      run: |
+        until wget https://repo1.maven.org/maven2/com/yubico/webauthn-server-attestation/${{ github.ref_name }}/webauthn-server-attestation-${{ github.ref_name }}.jar.asc; do sleep 180; done
+        until wget https://repo1.maven.org/maven2/com/yubico/webauthn-server-core/${{ github.ref_name }}/webauthn-server-core-${{ github.ref_name }}.jar.asc; do sleep 180; done
+
+    - name: Store keyring and signatures as artifact
+      uses: actions/upload-artifact@v3
+      with:
+        name: keyring-and-signatures
+        retention-days: 1
+        path: |
+          yubico.keyring
+          *.jar.asc
+
   verify:
     name: Verify signatures (JDK ${{ matrix.java }} ${{ matrix.distribution }})
-
+    needs: download
     runs-on: ubuntu-latest
+
     strategy:
       matrix:
         java: [17]
@@ -31,21 +59,34 @@ jobs:
         java --version
         ./gradlew jar
 
-    - name: Fetch keys
-      run: gpg --no-default-keyring --keyring ./yubico.keyring --keyserver hkps://keys.openpgp.org --recv-keys 57A9DEED4C6D962A923BB691816F3ED99921835E
-
-    - name: Verify signatures from GitHub release
-      run: |
-        wget https://github.com/${GITHUB_REPOSITORY}/releases/download/${{ github.ref_name }}/webauthn-server-attestation-${{ github.ref_name }}.jar.asc
-        wget https://github.com/${GITHUB_REPOSITORY}/releases/download/${{ github.ref_name }}/webauthn-server-core-${{ github.ref_name }}.jar.asc
-
-        gpg --no-default-keyring --keyring ./yubico.keyring --verify webauthn-server-attestation-${{ github.ref_name }}.jar.asc webauthn-server-attestation/build/libs/webauthn-server-attestation-${{ github.ref_name }}.jar
-        gpg --no-default-keyring --keyring ./yubico.keyring --verify webauthn-server-core-${{ github.ref_name }}.jar.asc webauthn-server-core/build/libs/webauthn-server-core-${{ github.ref_name }}.jar
+    - name: Retrieve keyring and signatures
+      uses: actions/download-artifact@v3
+      with:
+        name: keyring-and-signatures
 
     - name: Verify signatures from Maven Central
       run: |
-        wget -O webauthn-server-core-${{ github.ref_name }}.jar.mavencentral.asc https://repo1.maven.org/maven2/com/yubico/webauthn-server-core/${{ github.ref_name }}/webauthn-server-core-${{ github.ref_name }}.jar.asc
-        wget -O webauthn-server-attestation-${{ github.ref_name }}.jar.mavencentral.asc https://repo1.maven.org/maven2/com/yubico/webauthn-server-attestation/${{ github.ref_name }}/webauthn-server-attestation-${{ github.ref_name }}.jar.asc
+        gpg --no-default-keyring --keyring ./yubico.keyring --verify webauthn-server-attestation-${{ github.ref_name }}.jar.asc webauthn-server-attestation/build/libs/webauthn-server-attestation-${{ github.ref_name }}.jar
+        gpg --no-default-keyring --keyring ./yubico.keyring --verify webauthn-server-core-${{ github.ref_name }}.jar.asc webauthn-server-core/build/libs/webauthn-server-core-${{ github.ref_name }}.jar
 
-        gpg --no-default-keyring --keyring ./yubico.keyring --verify webauthn-server-attestation-${{ github.ref_name }}.jar.mavencentral.asc webauthn-server-attestation/build/libs/webauthn-server-attestation-${{ github.ref_name }}.jar
-        gpg --no-default-keyring --keyring ./yubico.keyring --verify webauthn-server-core-${{ github.ref_name }}.jar.mavencentral.asc webauthn-server-core/build/libs/webauthn-server-core-${{ github.ref_name }}.jar
+  upload:
+    name: Upload signatures to GitHub
+    needs: verify
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write  # Allow uploading release artifacts
+
+    steps:
+    - name: Retrieve signatures
+      uses: actions/download-artifact@v3
+      with:
+        name: keyring-and-signatures
+
+    - name: Upload signatures to GitHub
+      run: |
+        RELEASE_DATA=$(curl -H "Authorization: Bearer ${{ github.token }}" ${{ github.api_url }}/repos/${{ github.repository }}/releases/tags/${{ github.ref_name }})
+        UPLOAD_URL=$(jq -r .upload_url <<<"${RELEASE_DATA}" | sed 's/{?name,label}//')
+
+        curl -X POST -H "Authorization: Bearer ${{ github.token }}" -H 'Content-Type: text/plain' --data-binary @webauthn-server-attestation-${{ github.ref_name }}.jar.asc "${UPLOAD_URL}?name=webauthn-server-attestation-${{ github.ref_name }}.jar.asc"
+        curl -X POST -H "Authorization: Bearer ${{ github.token }}" -H 'Content-Type: text/plain' --data-binary @webauthn-server-core-${{ github.ref_name }}.jar.asc "${UPLOAD_URL}?name=webauthn-server-core-${{ github.ref_name }}.jar.asc"

--- a/build.gradle
+++ b/build.gradle
@@ -116,12 +116,6 @@ task assembleJavadoc(type: Sync) {
   destinationDir = file("${rootProject.buildDir}/javadoc")
 }
 
-task collectSignatures(type: Sync) {
-  destinationDir = file("${rootProject.buildDir}/dist")
-  duplicatesStrategy DuplicatesStrategy.FAIL
-  include '*.jar', '*.jar.asc'
-}
-
 subprojects { project ->
 
   if (project.plugins.hasPlugin('scala')) {
@@ -246,14 +240,6 @@ subprojects { project ->
       signing {
         useGpgCmd()
         sign publishing.publications.jars
-      }
-
-      tasks.withType(Sign) { Sign signTask ->
-        rootProject.tasks.collectSignatures {
-          from signTask.inputs.files
-          from signTask.outputs.files
-        }
-        signTask.finalizedBy rootProject.tasks.collectSignatures
       }
     }
   }

--- a/build.gradle
+++ b/build.gradle
@@ -116,6 +116,14 @@ task assembleJavadoc(type: Sync) {
   destinationDir = file("${rootProject.buildDir}/javadoc")
 }
 
+task checkJavaVersionBeforeRelease {
+  doFirst {
+    if (JavaVersion.current() != JavaVersion.VERSION_17) {
+      throw new RuntimeException('Release must be built using JDK 17. Current JDK version: ' + JavaVersion.current())
+    }
+  }
+}
+
 subprojects { project ->
 
   if (project.plugins.hasPlugin('scala')) {
@@ -148,14 +156,17 @@ subprojects { project ->
     reproducibleFileOrder = true
   }
 
-  tasks.withType(Sign) {
-    it.dependsOn check
-  }
-
   tasks.withType(AbstractTestTask) {
     testLogging {
       showStandardStreams = isCiBuild
     }
+  }
+
+  tasks.withType(AbstractCompile) { shouldRunAfter checkJavaVersionBeforeRelease }
+  tasks.withType(AbstractTestTask) { shouldRunAfter checkJavaVersionBeforeRelease }
+  tasks.withType(Sign) {
+    it.dependsOn check
+    dependsOn checkJavaVersionBeforeRelease
   }
 
   if (project.hasProperty('publishMe') && project.publishMe) {

--- a/doc/releasing.md
+++ b/doc/releasing.md
@@ -6,15 +6,13 @@ Release candidate versions
 
  1. Make sure release notes in `NEWS` are up to date.
 
- 2. Make sure you're running Gradle in JDK 17.
-
- 3. Run the tests one more time:
+ 2. Run the tests one more time:
 
     ```
     $ ./gradlew clean check
     ```
 
- 4. Tag the head commit with an `X.Y.Z-RCN` tag:
+ 3. Tag the head commit with an `X.Y.Z-RCN` tag:
 
     ```
     $ git tag -a -s 1.4.0-RC1 -m "Pre-release 1.4.0-RC1"
@@ -22,13 +20,13 @@ Release candidate versions
 
     No tag body needed.
 
- 5. Publish to Sonatype Nexus:
+ 4. Publish to Sonatype Nexus:
 
     ```
     $ ./gradlew publishToSonatype closeAndReleaseSonatypeStagingRepository
     ```
 
- 6. Push to GitHub.
+ 5. Push to GitHub.
 
     If the pre-release makes significant changes to the project README, such
     that the README does not accurately reflect the latest non-pre-release
@@ -46,7 +44,7 @@ Release candidate versions
     $ git push origin main 1.4.0-RC1
     ```
 
- 7. Make GitHub release.
+ 6. Make GitHub release.
 
     - Use the new tag as the release tag
     - Check the pre-release checkbox
@@ -55,7 +53,7 @@ Release candidate versions
       changes/additions since the previous release or pre-release.
     - Note which JDK version was used to build the artifacts.
 
- 8. Check that the ["Reproducible binary"
+ 7. Check that the ["Reproducible binary"
     workflow](/Yubico/java-webauthn-server/actions/workflows/release-verify-signatures.yml)
     runs and succeeds.
 
@@ -65,9 +63,7 @@ Release versions
 
  1. Make sure release notes in `NEWS` are up to date.
 
- 2. Make sure you're running Gradle in JDK 17.
-
- 3. Make a no-fast-forward merge from the last (non release candidate) release
+ 2. Make a no-fast-forward merge from the last (non release candidate) release
     to the commit to be released:
 
     ```
@@ -89,26 +85,26 @@ Release versions
     $ git branch -d release-1.4.0
     ```
 
- 4. Remove the "(unreleased)" tag from `NEWS`.
+ 3. Remove the "(unreleased)" tag from `NEWS`.
 
- 5. Update the version in the dependency snippets in the README.
+ 4. Update the version in the dependency snippets in the README.
 
- 6. Update the version in JavaDoc links in the READMEs.
+ 5. Update the version in JavaDoc links in the READMEs.
 
- 7. Amend these changes into the merge commit:
+ 6. Amend these changes into the merge commit:
 
     ```
     $ git add NEWS
     $ git commit --amend --reset-author
     ```
 
- 8. Run the tests one more time:
+ 7. Run the tests one more time:
 
     ```
     $ ./gradlew clean check
     ```
 
- 9. Tag the merge commit with an `X.Y.Z` tag:
+ 8. Tag the merge commit with an `X.Y.Z` tag:
 
     ```
     $ git tag -a -s 1.4.0 -m "Release 1.4.0"
@@ -116,19 +112,19 @@ Release versions
 
     No tag body needed since that's included in the commit.
 
-10. Publish to Sonatype Nexus:
+ 9. Publish to Sonatype Nexus:
 
     ```
     $ ./gradlew publishToSonatype closeAndReleaseSonatypeStagingRepository
     ```
 
-11. Push to GitHub:
+10. Push to GitHub:
 
     ```
     $ git push origin main 1.4.0
     ```
 
-12. Make GitHub release.
+11. Make GitHub release.
 
     - Use the new tag as the release tag
     - Copy the release notes from `NEWS` into the GitHub release notes; reformat
@@ -136,6 +132,6 @@ Release versions
       the previous release (not just changes since the previous pre-release).
     - Note which JDK version was used to build the artifacts.
 
-13. Check that the ["Reproducible binary"
+12. Check that the ["Reproducible binary"
     workflow](/Yubico/java-webauthn-server/actions/workflows/release-verify-signatures.yml)
     runs and succeeds.

--- a/doc/releasing.md
+++ b/doc/releasing.md
@@ -28,13 +28,7 @@ Release candidate versions
     $ ./gradlew publishToSonatype closeAndReleaseSonatypeStagingRepository
     ```
 
- 6. Wait for the artifacts to become downloadable at
-    https://repo1.maven.org/maven2/com/yubico/webauthn-server-core/ . This is
-    needed for one of the GitHub Actions release workflows and usually takes
-    less than 30 minutes (long before the artifacts become searchable on the
-    main Maven Central website).
-
- 7. Push to GitHub.
+ 6. Push to GitHub.
 
     If the pre-release makes significant changes to the project README, such
     that the README does not accurately reflect the latest non-pre-release
@@ -52,18 +46,18 @@ Release candidate versions
     $ git push origin main 1.4.0-RC1
     ```
 
- 8. Make GitHub release.
+ 7. Make GitHub release.
 
     - Use the new tag as the release tag
     - Check the pre-release checkbox
     - Copy the release notes from `NEWS` into the GitHub release notes; reformat
       from ASCIIdoc to Markdown and remove line wraps. Include only
       changes/additions since the previous release or pre-release.
-    - Attach the signature files from
-      `build/dist/webauthn-server-attestation-X.Y.Z-RCN.jar.asc`
-      and
-      `build/dist/webauthn-server-core-X.Y.Z-RCN.jar.asc`.
     - Note which JDK version was used to build the artifacts.
+
+ 8. Check that the ["Reproducible binary"
+    workflow](/Yubico/java-webauthn-server/actions/workflows/release-verify-signatures.yml)
+    runs and succeeds.
 
 
 Release versions
@@ -128,27 +122,20 @@ Release versions
     $ ./gradlew publishToSonatype closeAndReleaseSonatypeStagingRepository
     ```
 
-11. Wait for the artifacts to become downloadable at
-    https://repo1.maven.org/maven2/com/yubico/webauthn-server-core/ . This is
-    needed for one of the GitHub Actions release workflows and usually takes
-    less than 30 minutes (long before the artifacts become searchable on the
-    main Maven Central website).
-
-12. Push to GitHub:
+11. Push to GitHub:
 
     ```
     $ git push origin main 1.4.0
     ```
 
-13. Make GitHub release.
+12. Make GitHub release.
 
     - Use the new tag as the release tag
     - Copy the release notes from `NEWS` into the GitHub release notes; reformat
       from ASCIIdoc to Markdown and remove line wraps. Include all changes since
       the previous release (not just changes since the previous pre-release).
-    - Attach the signature files from
-      `build/dist/webauthn-server-attestation-X.Y.Z.jar.asc`
-      and
-      `build/dist/webauthn-server-core-X.Y.Z.jar.asc`.
-
     - Note which JDK version was used to build the artifacts.
+
+13. Check that the ["Reproducible binary"
+    workflow](/Yubico/java-webauthn-server/actions/workflows/release-verify-signatures.yml)
+    runs and succeeds.


### PR DESCRIPTION
The ["Reproducible build" workflow](https://github.com/Yubico/java-webauthn-server/actions/workflows/release-verify-signatures.yml) checks that fresh builds from source match the release signatures from Maven Central and the GitHub release. Because there's a bit of delay before artifacts become available on Maven Central, the developer needs to wait for that before publishing a GitHub release.

This change makes the workflow wait for the files to become available on Maven Central, and upload the signature files to the GitHub release instead of downloading them from there. The developer no longer needs to manually attach the signature files and does not need to wait before publishing the release.

Ping @Yubico/prodsec for visibility, you're welcome to review if you want to. :slightly_smiling_face: