### PR TITLE
Add extra-data field to `RegisteredCredential`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,9 @@ out/
 *.iws
 .attach_pid*
 
+# VS Code
+.vscode/
+
 # Mac
 .DS_Store
 

--- a/webauthn-server-core/src/main/java/com/yubico/webauthn/RegisteredCredential.java
+++ b/webauthn-server-core/src/main/java/com/yubico/webauthn/RegisteredCredential.java
@@ -196,8 +196,8 @@ public final class RegisteredCredential {
   }
 
   /**
-   * Opaque extra-data object provided by consumer code. The library will not access it in any
-   * way; however, it can be extracted using {@link #getExtraData(Class)}.
+   * Opaque extra-data object provided by consumer code. The library will not access it in any way;
+   * however, it can be extracted using {@link #getExtraData(Class)}.
    */
   @JsonIgnore
   @Getter(AccessLevel.NONE)
@@ -208,8 +208,8 @@ public final class RegisteredCredential {
    * Retrieves any extra data that was provided during building, unmodified.
    *
    * @param <T> The type of the stored extra data.
-   * @param assertedType The type of the stored extra data; a ClassCastException results in an
-   *     empty Optional.
+   * @param assertedType The type of the stored extra data; a ClassCastException results in an empty
+   *     Optional.
    * @return The opaque extra data stored during building, unmodified.
    */
   public <T> Optional<T> getExtraData(Class<T> assertedType) {

--- a/webauthn-server-core/src/test/java/com/yubico/webauthn/RegisteredCredentialTest.java
+++ b/webauthn-server-core/src/test/java/com/yubico/webauthn/RegisteredCredentialTest.java
@@ -1,0 +1,88 @@
+package com.yubico.webauthn;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.yubico.webauthn.data.ByteArray;
+import java.util.Optional;
+import org.junit.Test;
+
+public class RegisteredCredentialTest {
+
+  private static ByteArray blank() {
+    return new ByteArray(new byte[] {});
+  }
+
+  @Test
+  public void itHasTheseBuilderMethods() {
+    RegisteredCredential.builder()
+        .credentialId(blank())
+        .userHandle(blank())
+        .publicKeyCose(blank())
+        .build();
+  }
+
+  @Test
+  public void extraDataIsOptional() {
+    final RegisteredCredential obj =
+        RegisteredCredential.builder()
+            .credentialId(blank())
+            .userHandle(blank())
+            .publicKeyCose(blank())
+            .build();
+    assertFalse(obj.getExtraData(Object.class).isPresent());
+  }
+
+  static class Foo {
+    final String dummyValueForJson = "";
+  }
+
+  static class Bar {}
+
+  @Test
+  public void extraDataIsPreserved() {
+    final Foo expectedAD = new Foo();
+    final RegisteredCredential obj =
+        RegisteredCredential.builder()
+            .credentialId(blank())
+            .userHandle(blank())
+            .publicKeyCose(blank())
+            .extraData(expectedAD)
+            .build();
+
+    final Optional<Foo> actualAD = obj.getExtraData(Foo.class);
+    assertTrue(actualAD.isPresent() && actualAD.get() == expectedAD);
+  }
+
+  @Test
+  public void extraDataIsTypeSafe() {
+    final RegisteredCredential obj =
+        RegisteredCredential.builder()
+            .credentialId(blank())
+            .userHandle(blank())
+            .publicKeyCose(blank())
+            .extraData(new Foo())
+            .build();
+    assertFalse(obj.getExtraData(Bar.class).isPresent());
+  }
+
+  @Test
+  public void extraDataIsNotSerialized() throws JsonProcessingException {
+    final RegisteredCredential one =
+        RegisteredCredential.builder()
+            .credentialId(blank())
+            .userHandle(blank())
+            .publicKeyCose(blank())
+            .build();
+    final RegisteredCredential two = one.toBuilder().extraData(new Foo()).build();
+
+    final ObjectMapper mapper = new ObjectMapper();
+    final String expected = mapper.writeValueAsString(one);
+    final String actual = mapper.writeValueAsString(two);
+    assertEquals(expected, actual);
+    assertEquals(one, mapper.readValue(actual, RegisteredCredential.class));
+  }
+}


### PR DESCRIPTION
As discussed in #274, this proposes an opaque, type-safe extra-data field on `RegisteredCredential`. This field can be used by library consumers to pass arbitrary data from their credential repository back up to their business logic.

I've additionally taken the liberty of replacing the `@JsonCreator` constructor with Lombok's `@Jacksonized` on the class itself; this should be equivalent for JSON deserialization purposes (the test cases check this), but allows the Lombok `@Builder` annotation to generate its own private constructor.