### PR TITLE
Expose UserIdentity in AssertionResult

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,9 @@ out/
 *.iws
 .attach_pid*
 
+# VS Code
+.vscode/
+
 # Mac
 .DS_Store
 

--- a/webauthn-server-core/src/main/java/com/yubico/webauthn/AssertionResult.java
+++ b/webauthn-server-core/src/main/java/com/yubico/webauthn/AssertionResult.java
@@ -69,11 +69,16 @@ public class AssertionResult {
   private final RegisteredCredential credential;
 
   /**
+   * The authenticated user.
+   */
+  @NonNull private final UserIdentity user;
+
+  /**
    * The username of the authenticated user.
    *
    * @see #getUserHandle()
    */
-  @NonNull private final String username;
+  private final @NonNull String getUsername() { return this.user.getName(); }
 
   /**
    * <code>true</code> if and only if at least one of the following is true:
@@ -103,12 +108,12 @@ public class AssertionResult {
           PublicKeyCredential<AuthenticatorAssertionResponse, ClientAssertionExtensionOutputs>
               credentialResponse,
       @NonNull @JsonProperty("credential") RegisteredCredential credential,
-      @NonNull @JsonProperty("username") String username,
+      @NonNull @JsonProperty("user") UserIdentity user,
       @JsonProperty("signatureCounterValid") boolean signatureCounterValid) {
     this.success = success;
     this.credentialResponse = credentialResponse;
     this.credential = credential;
-    this.username = username;
+    this.user = user;
     this.signatureCounterValid = signatureCounterValid;
   }
 

--- a/webauthn-server-core/src/main/java/com/yubico/webauthn/AssertionResult.java
+++ b/webauthn-server-core/src/main/java/com/yubico/webauthn/AssertionResult.java
@@ -68,9 +68,7 @@ public class AssertionResult {
    */
   private final RegisteredCredential credential;
 
-  /**
-   * The authenticated user.
-   */
+  /** The authenticated user. */
   @NonNull private final UserIdentity user;
 
   /**
@@ -78,7 +76,9 @@ public class AssertionResult {
    *
    * @see #getUserHandle()
    */
-  public final @NonNull String getUsername() { return this.user.getName(); }
+  public final @NonNull String getUsername() {
+    return this.user.getName();
+  }
 
   /**
    * <code>true</code> if and only if at least one of the following is true:

--- a/webauthn-server-core/src/main/java/com/yubico/webauthn/AssertionResult.java
+++ b/webauthn-server-core/src/main/java/com/yubico/webauthn/AssertionResult.java
@@ -78,7 +78,7 @@ public class AssertionResult {
    *
    * @see #getUserHandle()
    */
-  private final @NonNull String getUsername() { return this.user.getName(); }
+  public final @NonNull String getUsername() { return this.user.getName(); }
 
   /**
    * <code>true</code> if and only if at least one of the following is true:

--- a/webauthn-server-core/src/main/java/com/yubico/webauthn/FinishAssertionSteps.java
+++ b/webauthn-server-core/src/main/java/com/yubico/webauthn/FinishAssertionSteps.java
@@ -130,18 +130,21 @@ final class FinishAssertionSteps {
             request.getUserHandle(),
             () -> request.getUsername().flatMap(credentialRepository::getUserHandleForUsername));
 
-    private final Optional<ByteArray> assertedUserHandle =
-        response.getResponse().getUserHandle();
-    
+    private final Optional<ByteArray> assertedUserHandle = response.getResponse().getUserHandle();
+
     private final Optional<ByteArray> userHandle =
         OptionalUtil.orElseOptional(assertedUserHandle, () -> requestedUserHandle);
-      
-    private final Optional<String> username = OptionalUtil.orElseOptional(
-        request.getUsername(),
-        () -> assertedUserHandle.flatMap(credentialRepository::getUsernameForUserHandle));
-    
-    private final Optional<UserIdentity> userIdentity = username.flatMap(un -> 
-        assertedUserHandle.map(uh -> UserIdentity.builder().name(un).displayName(un).id(uh).build()));
+
+    private final Optional<String> username =
+        OptionalUtil.orElseOptional(
+            request.getUsername(),
+            () -> assertedUserHandle.flatMap(credentialRepository::getUsernameForUserHandle));
+
+    private final Optional<UserIdentity> userIdentity =
+        username.flatMap(
+            un ->
+                assertedUserHandle.map(
+                    uh -> UserIdentity.builder().name(un).displayName(un).id(uh).build()));
 
     private final Optional<RegisteredCredential> registration =
         assertedUserHandle.flatMap(uh -> credentialRepository.lookup(response.getId(), uh));


### PR DESCRIPTION
This is part of the `UserIdentity` work I proposed in https://github.com/Yubico/java-webauthn-server/issues/289#issuecomment-1572100280; I am breaking it down into smaller parts for ease of review.

This PR simply builds a `UserIdentity` in step 6 of `FinishAssertionSteps` (from the existing information) and passes it through to the final `AssertionResult`. For now, this does not enable additional functionality; however, it is necessary groundwork for being able to specify `UserIdentity` in `StartAssertionOptions` in the future.

I've also taken the liberty of restructuring step 6 a bit to make it easier to follow.