### PR TITLE
Add `CredentialRepositoryV2` to supersede `CredentialRepository`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,9 @@ out/
 *.iws
 .attach_pid*
 
+# VS Code
+.vscode/
+
 # Mac
 .DS_Store
 

--- a/webauthn-server-core/src/main/java/com/yubico/webauthn/CredentialRepository.java
+++ b/webauthn-server-core/src/main/java/com/yubico/webauthn/CredentialRepository.java
@@ -29,6 +29,7 @@ import com.yubico.webauthn.data.PublicKeyCredentialDescriptor;
 import com.yubico.webauthn.data.UserIdentity;
 import java.util.Optional;
 import java.util.Set;
+import lombok.NonNull;
 
 /**
  * An abstraction of the database lookups needed by this library.
@@ -48,7 +49,8 @@ public interface CredentialRepository extends CredentialRepositoryV2 {
    * <p>After a successful registration ceremony, the {@link RegistrationResult#getKeyId()} method
    * returns a value suitable for inclusion in this set.
    */
-  Set<PublicKeyCredentialDescriptor> getCredentialIdsForUsername(String username);
+  @NonNull
+  Set<PublicKeyCredentialDescriptor> getCredentialIdsForUsername(@NonNull String username);
 
   /**
    * Get the user handle corresponding to the given username - the inverse of {@link
@@ -57,7 +59,8 @@ public interface CredentialRepository extends CredentialRepositoryV2 {
    * <p>Used to look up the user handle based on the username, for authentication ceremonies where
    * the username is already given.
    */
-  Optional<ByteArray> getUserHandleForUsername(String username);
+  @NonNull
+  Optional<ByteArray> getUserHandleForUsername(@NonNull String username);
 
   /**
    * Get the username corresponding to the given user handle - the inverse of {@link
@@ -66,7 +69,8 @@ public interface CredentialRepository extends CredentialRepositoryV2 {
    * <p>Used to look up the username based on the user handle, for username-less authentication
    * ceremonies.
    */
-  Optional<String> getUsernameForUserHandle(ByteArray userHandle);
+  @NonNull
+  Optional<String> getUsernameForUserHandle(@NonNull ByteArray userHandle);
 
   /**
    * Look up the public key and stored signature count for the given credential registered to the
@@ -75,29 +79,36 @@ public interface CredentialRepository extends CredentialRepositoryV2 {
    * <p>The returned {@link RegisteredCredential} is not expected to be long-lived. It may be read
    * directly from a database or assembled from other components.
    */
-  Optional<RegisteredCredential> lookup(ByteArray credentialId, ByteArray userHandle);
+  @NonNull
+  Optional<RegisteredCredential> lookup(
+      @NonNull ByteArray credentialId, @NonNull ByteArray userHandle);
 
   /// map the methods of the new interface to the methods on the old interface
 
   @Override
-  default Set<PublicKeyCredentialDescriptor> getCredentialIdsForUser(UserIdentity user) {
+  @NonNull
+  default Set<PublicKeyCredentialDescriptor> getCredentialIdsForUser(@NonNull UserIdentity user) {
     return getCredentialIdsForUsername(user.getName());
   }
 
   @Override
-  default Optional<UserIdentity> findUserByUsername(String username) {
+  @NonNull
+  default Optional<UserIdentity> findUserByUsername(@NonNull String username) {
     return getUserHandleForUsername(username)
         .map(uh -> UserIdentity.builder().name(username).displayName(username).id(uh).build());
   }
 
   @Override
-  default Optional<UserIdentity> findUserByUserHandle(ByteArray userHandle) {
+  @NonNull
+  default Optional<UserIdentity> findUserByUserHandle(@NonNull ByteArray userHandle) {
     return getUsernameForUserHandle(userHandle)
         .map(un -> UserIdentity.builder().name(un).displayName(un).id(userHandle).build());
   }
 
   @Override
-  default Optional<RegisteredCredential> lookup(ByteArray credentialId, UserIdentity identity) {
+  @NonNull
+  default Optional<RegisteredCredential> lookup(
+      @NonNull ByteArray credentialId, @NonNull UserIdentity identity) {
     return lookup(credentialId, identity.getId());
   }
 }

--- a/webauthn-server-core/src/main/java/com/yubico/webauthn/CredentialRepository.java
+++ b/webauthn-server-core/src/main/java/com/yubico/webauthn/CredentialRepository.java
@@ -68,7 +68,14 @@ public interface CredentialRepository extends CredentialRepositoryV2 {
    */
   Optional<String> getUsernameForUserHandle(ByteArray userHandle);
 
-
+  /**
+   * Look up the public key and stored signature count for the given credential registered to the
+   * given user.
+   *
+   * <p>The returned {@link RegisteredCredential} is not expected to be long-lived. It may be read
+   * directly from a database or assembled from other components.
+   */
+  Optional<RegisteredCredential> lookup(ByteArray credentialId, ByteArray userHandle);
 
 
 
@@ -87,5 +94,10 @@ public interface CredentialRepository extends CredentialRepositoryV2 {
   @Override
   default Optional<UserIdentity> findUserByUserHandle(ByteArray userHandle) {
       return getUsernameForUserHandle(userHandle).map(un -> UserIdentity.builder().name(un).displayName(un).id(userHandle).build());
+  }
+
+  @Override
+  default Optional<RegisteredCredential> lookup(ByteArray credentialId, UserIdentity identity) {
+    return lookup(credentialId, identity.getId());
   }
 }

--- a/webauthn-server-core/src/main/java/com/yubico/webauthn/CredentialRepository.java
+++ b/webauthn-server-core/src/main/java/com/yubico/webauthn/CredentialRepository.java
@@ -27,7 +27,6 @@ package com.yubico.webauthn;
 import com.yubico.webauthn.data.ByteArray;
 import com.yubico.webauthn.data.PublicKeyCredentialDescriptor;
 import com.yubico.webauthn.data.UserIdentity;
-
 import java.util.Optional;
 import java.util.Set;
 
@@ -36,8 +35,9 @@ import java.util.Set;
  *
  * <p>This is used by {@link RelyingParty} to look up credentials, usernames and user handles from
  * usernames, user handles and credential IDs.
- * 
- * @deprecated this interface is provided for backwards compatibility; use {@link CredentialRepositoryV2} instead
+ *
+ * @deprecated this interface is provided for backwards compatibility; use {@link
+ *     CredentialRepositoryV2} instead
  */
 @Deprecated
 public interface CredentialRepository extends CredentialRepositoryV2 {
@@ -77,8 +77,6 @@ public interface CredentialRepository extends CredentialRepositoryV2 {
    */
   Optional<RegisteredCredential> lookup(ByteArray credentialId, ByteArray userHandle);
 
-
-
   /// map the methods of the new interface to the methods on the old interface
 
   @Override
@@ -88,12 +86,14 @@ public interface CredentialRepository extends CredentialRepositoryV2 {
 
   @Override
   default Optional<UserIdentity> findUserByUsername(String username) {
-      return getUserHandleForUsername(username).map(uh -> UserIdentity.builder().name(username).displayName(username).id(uh).build());
+    return getUserHandleForUsername(username)
+        .map(uh -> UserIdentity.builder().name(username).displayName(username).id(uh).build());
   }
 
   @Override
   default Optional<UserIdentity> findUserByUserHandle(ByteArray userHandle) {
-      return getUsernameForUserHandle(userHandle).map(un -> UserIdentity.builder().name(un).displayName(un).id(userHandle).build());
+    return getUsernameForUserHandle(userHandle)
+        .map(un -> UserIdentity.builder().name(un).displayName(un).id(userHandle).build());
   }
 
   @Override

--- a/webauthn-server-core/src/main/java/com/yubico/webauthn/CredentialRepositoryV2.java
+++ b/webauthn-server-core/src/main/java/com/yubico/webauthn/CredentialRepositoryV2.java
@@ -1,0 +1,96 @@
+// Copyright (c) 2018, Yubico AB
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this
+//    list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+package com.yubico.webauthn;
+
+import java.util.Optional;
+import java.util.Set;
+
+import com.yubico.webauthn.data.ByteArray;
+import com.yubico.webauthn.data.PublicKeyCredentialDescriptor;
+import com.yubico.webauthn.data.UserIdentity;
+
+/**
+ * An abstraction of the database lookups needed by this library.
+ *
+ * <p>This is used by {@link RelyingParty} to look up credentials, usernames and user handles from
+ * usernames, user handles and credential IDs.
+ */
+public interface CredentialRepositoryV2 {
+    /**
+   * Get the credential IDs of all credentials registered to the given user.
+   * 
+   * <p>After a successful registration ceremony, the {@link RegistrationResult#getKeyId()} method
+   * returns a value suitable for inclusion in this set.
+   * 
+   * <p>This method is invoked from {@link RelyingParty#startRegistration(StartRegistrationOptions)}.
+   * In this case, it is passed the UserIdentity specified in {@link StartRegistrationOptions#getUser()}.
+   * 
+   * <p>Additionally, this method is invoked from {@link RelyingParty#startAssertion(StartAssertionOptions)} if
+   * {@link StartAssertionOptions#getUser()} is present, with that UserIdentity. If {@link StartAssertionOptions#getUsername()}
+   * or {@link StartAssertionOptions#getUserHandle()} are present, it is invoked with the return value of
+   * {@link #findUserByUsername(String)} or {@link #findUserByUserHandle(ByteArray)} respectively, instead.
+   */
+  Set<PublicKeyCredentialDescriptor> getCredentialIdsForUser(UserIdentity user);
+
+  /**
+   * Builds a UserIdentity corresponding to the given username.
+   *
+   * <p>This is only invoked from {@link RelyingParty#startAssertion(StartAssertionOptions)}, and only if
+   * {@link StartAssertionOptions#getUsername()} is present.
+   */
+  Optional<UserIdentity> findUserByUsername(String username);
+
+  /**
+   * Builds a UserIdentity corresponding to the given user handle.
+   *
+   * <p>This is invoked from {@link RelyingParty#startAssertion(StartAssertionOptions)} only if
+   * {@link StartAssertionOptions#getUserHandle()} is present.
+   * 
+   * <p>Additionally, when authenticating using a discoverable credential (passkey), i.e., if none of
+   * {@link StartAssertionOptions#getUser()}, {@link StartAssertionOptions#getUsername()} and
+   * {@link StartAssertionOptions#getUserHandle()} are present, this is invoked from
+   * {@link RelyingParty#finishAssertion(FinishAssertionOptions)}, with the credential's user handle.
+   */
+  Optional<UserIdentity> findUserByUserHandle(ByteArray userHandle);
+
+  /**
+   * Look up the public key and stored signature count for the given credential registered to the
+   * given user.
+   *
+   * <p>The returned {@link RegisteredCredential} is not expected to be long-lived. It may be read
+   * directly from a database or assembled from other components.
+   */
+  Optional<RegisteredCredential> lookup(ByteArray credentialId, ByteArray userHandle);
+
+  /**
+   * Look up all credentials with the given credential ID, regardless of what user they're
+   * registered to.
+   *
+   * <p>This is used to refuse registration of duplicate credential IDs. Therefore, under normal
+   * circumstances this method should only return zero or one credential (this is an expected
+   * consequence, not an interface requirement).
+   */
+  Set<RegisteredCredential> lookupAll(ByteArray credentialId);
+}

--- a/webauthn-server-core/src/main/java/com/yubico/webauthn/CredentialRepositoryV2.java
+++ b/webauthn-server-core/src/main/java/com/yubico/webauthn/CredentialRepositoryV2.java
@@ -29,6 +29,7 @@ import com.yubico.webauthn.data.PublicKeyCredentialDescriptor;
 import com.yubico.webauthn.data.UserIdentity;
 import java.util.Optional;
 import java.util.Set;
+import lombok.NonNull;
 
 /**
  * An abstraction of the database lookups needed by this library.
@@ -54,7 +55,8 @@ public interface CredentialRepositoryV2 {
    * {@link #findUserByUsername(String)} or {@link #findUserByUserHandle(ByteArray)} respectively,
    * instead.
    */
-  Set<PublicKeyCredentialDescriptor> getCredentialIdsForUser(UserIdentity user);
+  @NonNull
+  Set<PublicKeyCredentialDescriptor> getCredentialIdsForUser(@NonNull UserIdentity user);
 
   /**
    * Builds a UserIdentity corresponding to the given username.
@@ -62,7 +64,8 @@ public interface CredentialRepositoryV2 {
    * <p>This is only invoked from {@link RelyingParty#startAssertion(StartAssertionOptions)}, and
    * only if {@link StartAssertionOptions#getUsername()} is present.
    */
-  Optional<UserIdentity> findUserByUsername(String username);
+  @NonNull
+  Optional<UserIdentity> findUserByUsername(@NonNull String username);
 
   /**
    * Builds a UserIdentity corresponding to the given user handle.
@@ -75,7 +78,8 @@ public interface CredentialRepositoryV2 {
    * {@link StartAssertionOptions#getUserHandle()} are present, this is invoked from {@link
    * RelyingParty#finishAssertion(FinishAssertionOptions)}, with the credential's user handle.
    */
-  Optional<UserIdentity> findUserByUserHandle(ByteArray userHandle);
+  @NonNull
+  Optional<UserIdentity> findUserByUserHandle(@NonNull ByteArray userHandle);
 
   /**
    * Look up the public key and stored signature count for the given credential registered to the
@@ -84,7 +88,9 @@ public interface CredentialRepositoryV2 {
    * <p>The returned {@link RegisteredCredential} is not expected to be long-lived. It may be read
    * directly from a database or assembled from other components.
    */
-  Optional<RegisteredCredential> lookup(ByteArray credentialId, UserIdentity user);
+  @NonNull
+  Optional<RegisteredCredential> lookup(
+      @NonNull ByteArray credentialId, @NonNull UserIdentity user);
 
   /**
    * Look up all credentials with the given credential ID, regardless of what user they're
@@ -94,5 +100,6 @@ public interface CredentialRepositoryV2 {
    * circumstances this method should only return zero or one credential (this is an expected
    * consequence, not an interface requirement).
    */
-  Set<RegisteredCredential> lookupAll(ByteArray credentialId);
+  @NonNull
+  Set<RegisteredCredential> lookupAll(@NonNull ByteArray credentialId);
 }

--- a/webauthn-server-core/src/main/java/com/yubico/webauthn/CredentialRepositoryV2.java
+++ b/webauthn-server-core/src/main/java/com/yubico/webauthn/CredentialRepositoryV2.java
@@ -24,12 +24,11 @@
 
 package com.yubico.webauthn;
 
-import java.util.Optional;
-import java.util.Set;
-
 import com.yubico.webauthn.data.ByteArray;
 import com.yubico.webauthn.data.PublicKeyCredentialDescriptor;
 import com.yubico.webauthn.data.UserIdentity;
+import java.util.Optional;
+import java.util.Set;
 
 /**
  * An abstraction of the database lookups needed by this library.
@@ -38,27 +37,30 @@ import com.yubico.webauthn.data.UserIdentity;
  * usernames, user handles and credential IDs.
  */
 public interface CredentialRepositoryV2 {
-    /**
+  /**
    * Get the credential IDs of all credentials registered to the given user.
-   * 
+   *
    * <p>After a successful registration ceremony, the {@link RegistrationResult#getKeyId()} method
    * returns a value suitable for inclusion in this set.
-   * 
-   * <p>This method is invoked from {@link RelyingParty#startRegistration(StartRegistrationOptions)}.
-   * In this case, it is passed the UserIdentity specified in {@link StartRegistrationOptions#getUser()}.
-   * 
-   * <p>Additionally, this method is invoked from {@link RelyingParty#startAssertion(StartAssertionOptions)} if
-   * {@link StartAssertionOptions#getUser()} is present, with that UserIdentity. If {@link StartAssertionOptions#getUsername()}
-   * or {@link StartAssertionOptions#getUserHandle()} are present, it is invoked with the return value of
-   * {@link #findUserByUsername(String)} or {@link #findUserByUserHandle(ByteArray)} respectively, instead.
+   *
+   * <p>This method is invoked from {@link
+   * RelyingParty#startRegistration(StartRegistrationOptions)}. In this case, it is passed the
+   * UserIdentity specified in {@link StartRegistrationOptions#getUser()}.
+   *
+   * <p>Additionally, this method is invoked from {@link
+   * RelyingParty#startAssertion(StartAssertionOptions)} if {@link StartAssertionOptions#getUser()}
+   * is present, with that UserIdentity. If {@link StartAssertionOptions#getUsername()} or {@link
+   * StartAssertionOptions#getUserHandle()} are present, it is invoked with the return value of
+   * {@link #findUserByUsername(String)} or {@link #findUserByUserHandle(ByteArray)} respectively,
+   * instead.
    */
   Set<PublicKeyCredentialDescriptor> getCredentialIdsForUser(UserIdentity user);
 
   /**
    * Builds a UserIdentity corresponding to the given username.
    *
-   * <p>This is only invoked from {@link RelyingParty#startAssertion(StartAssertionOptions)}, and only if
-   * {@link StartAssertionOptions#getUsername()} is present.
+   * <p>This is only invoked from {@link RelyingParty#startAssertion(StartAssertionOptions)}, and
+   * only if {@link StartAssertionOptions#getUsername()} is present.
    */
   Optional<UserIdentity> findUserByUsername(String username);
 
@@ -67,11 +69,11 @@ public interface CredentialRepositoryV2 {
    *
    * <p>This is invoked from {@link RelyingParty#startAssertion(StartAssertionOptions)} only if
    * {@link StartAssertionOptions#getUserHandle()} is present.
-   * 
-   * <p>Additionally, when authenticating using a discoverable credential (passkey), i.e., if none of
-   * {@link StartAssertionOptions#getUser()}, {@link StartAssertionOptions#getUsername()} and
-   * {@link StartAssertionOptions#getUserHandle()} are present, this is invoked from
-   * {@link RelyingParty#finishAssertion(FinishAssertionOptions)}, with the credential's user handle.
+   *
+   * <p>Additionally, when authenticating using a discoverable credential (passkey), i.e., if none
+   * of {@link StartAssertionOptions#getUser()}, {@link StartAssertionOptions#getUsername()} and
+   * {@link StartAssertionOptions#getUserHandle()} are present, this is invoked from {@link
+   * RelyingParty#finishAssertion(FinishAssertionOptions)}, with the credential's user handle.
    */
   Optional<UserIdentity> findUserByUserHandle(ByteArray userHandle);
 

--- a/webauthn-server-core/src/main/java/com/yubico/webauthn/CredentialRepositoryV2.java
+++ b/webauthn-server-core/src/main/java/com/yubico/webauthn/CredentialRepositoryV2.java
@@ -82,7 +82,7 @@ public interface CredentialRepositoryV2 {
    * <p>The returned {@link RegisteredCredential} is not expected to be long-lived. It may be read
    * directly from a database or assembled from other components.
    */
-  Optional<RegisteredCredential> lookup(ByteArray credentialId, ByteArray userHandle);
+  Optional<RegisteredCredential> lookup(ByteArray credentialId, UserIdentity user);
 
   /**
    * Look up all credentials with the given credential ID, regardless of what user they're


### PR DESCRIPTION
This is part of the `UserIdentity` work I proposed in https://github.com/Yubico/java-webauthn-server/issues/289#issuecomment-1572100280; I am breaking it down into smaller parts for ease of review.

This part supersedes the current `CredentialRepository` interface with a new `CredentialRepositoryV2` interface. `CredentialRepositoryV2` works based on `UserIdentity` objects, not usernames.

The `CredentialRepository` interface extends `CredentialRepositoryV2`, and has appropriate `default` implementations to allow existing repositories to continue to function unmodified.

_(This pull request does not actually use the `V2` interface or its functions anywhere, yet.)_