### PR TITLE
Add extra-data field to `UserIdentity`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,9 @@ out/
 *.iws
 .attach_pid*
 
+# VS Code
+.vscode/
+
 # Mac
 .DS_Store
 

--- a/webauthn-server-core/src/main/java/com/yubico/webauthn/data/UserIdentity.java
+++ b/webauthn-server-core/src/main/java/com/yubico/webauthn/data/UserIdentity.java
@@ -24,12 +24,14 @@
 
 package com.yubico.webauthn.data;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import java.util.Optional;
+import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NonNull;
 import lombok.Value;
+import lombok.extern.jackson.Jacksonized;
 
 /**
  * Describes a user account, with which public key credentials can be associated.
@@ -40,6 +42,7 @@ import lombok.Value;
  *     </a>
  */
 @Value
+@Jacksonized
 @Builder(toBuilder = true)
 public class UserIdentity implements PublicKeyCredentialEntity {
 
@@ -101,14 +104,29 @@ public class UserIdentity implements PublicKeyCredentialEntity {
    */
   @NonNull private final ByteArray id;
 
-  @JsonCreator
-  private UserIdentity(
-      @NonNull @JsonProperty("name") String name,
-      @NonNull @JsonProperty("displayName") String displayName,
-      @NonNull @JsonProperty("id") ByteArray id) {
-    this.name = name;
-    this.displayName = displayName;
-    this.id = id;
+  /**
+   * Opaque extra-data object provided by consumer code. The library will not access it in any
+   * way; however, it can be extracted using {@link #getExtraData(Class)}.
+   */
+  @JsonIgnore
+  @Getter(AccessLevel.NONE)
+  @Builder.Default
+  private final Object extraData = null;
+
+  /**
+   * Retrieves any extra data that was provided during building, unmodified.
+   *
+   * @param <T> The type of the stored extra data.
+   * @param assertedType The type of the stored extra data; a ClassCastException results in an
+   *     empty Optional.
+   * @return The opaque extra data stored during building, unmodified.
+   */
+  public <T> Optional<T> getExtraData(Class<T> assertedType) {
+    try {
+      return Optional.ofNullable(extraData).map(assertedType::cast);
+    } catch (ClassCastException ex) {
+      return Optional.empty();
+    }
   }
 
   public static UserIdentityBuilder.MandatoryStages builder() {

--- a/webauthn-server-core/src/test/java/com/yubico/webauthn/data/UserIdentityTest.java
+++ b/webauthn-server-core/src/test/java/com/yubico/webauthn/data/UserIdentityTest.java
@@ -1,5 +1,12 @@
 package com.yubico.webauthn.data;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.Optional;
 import org.junit.Test;
 
 public class UserIdentityTest {
@@ -7,5 +14,58 @@ public class UserIdentityTest {
   @Test
   public void itHasTheseBuilderMethods() {
     UserIdentity.builder().name("").displayName("").id(new ByteArray(new byte[] {})).build();
+  }
+
+  @Test
+  public void extraDataIsOptional() {
+    final UserIdentity obj =
+        UserIdentity.builder().name("").displayName("").id(new ByteArray(new byte[] {})).build();
+    assertFalse(obj.getExtraData(Object.class).isPresent());
+  }
+
+  static class Foo {
+    final String dummyValueForJson = "";
+  }
+
+  static class Bar {}
+
+  @Test
+  public void extraDataIsPreserved() {
+    final Foo expectedAD = new Foo();
+    final UserIdentity obj =
+        UserIdentity.builder()
+            .name("")
+            .displayName("")
+            .id(new ByteArray(new byte[] {}))
+            .extraData(expectedAD)
+            .build();
+
+    final Optional<Foo> actualAD = obj.getExtraData(Foo.class);
+    assertTrue(actualAD.isPresent() && actualAD.get() == expectedAD);
+  }
+
+  @Test
+  public void extraDataIsTypeSafe() {
+    final UserIdentity obj =
+        UserIdentity.builder()
+            .name("")
+            .displayName("")
+            .id(new ByteArray(new byte[] {}))
+            .extraData(new Foo())
+            .build();
+    assertFalse(obj.getExtraData(Bar.class).isPresent());
+  }
+
+  @Test
+  public void extraDataIsNotSerialized() throws JsonProcessingException {
+    final UserIdentity one =
+        UserIdentity.builder().name("").displayName("").id(new ByteArray(new byte[] {})).build();
+    final UserIdentity two = one.toBuilder().extraData(new Foo()).build();
+
+    final ObjectMapper mapper = new ObjectMapper();
+    final String expected = mapper.writeValueAsString(one);
+    final String actual = mapper.writeValueAsString(two);
+    assertEquals(expected, actual);
+    assertEquals(one, mapper.readValue(actual, UserIdentity.class));
   }
 }


### PR DESCRIPTION
This is part of the `UserIdentity` work I proposed in https://github.com/Yubico/java-webauthn-server/issues/289#issuecomment-1572100280; I am breaking it down into smaller parts for ease of review.

In parallel to #290, this proposes an opaque, type-safe extra-data field on `UserIdentity`. This field can be used by library consumers to pass arbitrary data from their business logic to their credential repository.

I've additionally taken the liberty of replacing the `@JsonCreator` constructor with Lombok's `@Jacksonized` on the class itself; this should be equivalent for JSON deserialization purposes (the test cases check this), but allows the Lombok `@Builder` annotation to generate its own private constructor.