### PR TITLE
supporting empty allow credentials list (during authentication)

### DIFF
--- a/webauthn-server-core/src/main/java/com/yubico/webauthn/FinishAssertionSteps.java
+++ b/webauthn-server-core/src/main/java/com/yubico/webauthn/FinishAssertionSteps.java
@@ -111,17 +111,18 @@ final class FinishAssertionSteps {
       request
           .getPublicKeyCredentialRequestOptions()
           .getAllowCredentials()
+          .filter(allowedCredentials -> !allowedCredentials.isEmpty())
           .ifPresent(
-              allowed -> {
+              allowed ->
                 assertTrue(
                     allowed.stream().anyMatch(allow -> allow.getId().equals(response.getId())),
                     "Unrequested credential ID: %s",
-                    response.getId());
-              });
+                    response.getId())
+              );
     }
   }
 
-  @Value
+  @Value""
   class Step6 implements Step<Step7> {
 
     private final Optional<ByteArray> userHandle =


### PR DESCRIPTION
Suggesting this PR as a fix fir the issues discussed in https://github.com/Yubico/java-webauthn-server/issues/300.
Basically, allowCredential being an empty optional is not enough for username less flow.
It should be an empty list.
Fundamentally, a list wrapped by an optional is a bad idea but itself. But solving that issue would have taken too much time.   