### PR TITLE
Fix incompatibility with Jackson 2.17.0-rc1

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -3,8 +3,7 @@
 Changes:
 
 * Dropped dependency on COSE-Java.
-* Excluded Jackson version 2.17.0-rc1 from dependency resolution due to an
-  incompatible regression.
+* Fixed incompatibility with Jackson version 2.17.0-rc1.
 
 
 == Version 2.5.0 ==

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -19,10 +19,7 @@ dependencyResolutionManagement {
             library("httpclient5", "org.apache.httpcomponents.client5:httpclient5:[5.0.0,6)")
             library("slf4j", "org.slf4j:slf4j-api:[1.7.25,3)")
 
-            val jacksonVer = version("jackson") {
-                require("[2.13.2.1,3)")
-                reject("2.17.0-rc1") // Regression: https://github.com/FasterXML/jackson-databind/issues/4413
-            }
+            val jacksonVer = version("jackson", "[2.13.2.1,3)")
             library("jackson-bom", "com.fasterxml.jackson", "jackson-bom").versionRef(jacksonVer)
             library("jackson-databind", "com.fasterxml.jackson.core", "jackson-databind").versionRef(jacksonVer)
             library("jackson-dataformat-cbor", "com.fasterxml.jackson.dataformat", "jackson-dataformat-cbor").versionRef(jacksonVer)

--- a/webauthn-server-attestation/src/main/java/com/yubico/fido/metadata/MetadataBLOBHeader.java
+++ b/webauthn-server-attestation/src/main/java/com/yubico/fido/metadata/MetadataBLOBHeader.java
@@ -1,5 +1,6 @@
 package com.yubico.fido.metadata;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import java.net.URL;
@@ -86,6 +87,9 @@ public class MetadataBLOBHeader {
    * @see <a href="https://datatracker.ietf.org/doc/html/rfc7515#section-4.1.6">RFC 7515 §4.1.6.
    *     "x5c" (X.509 Certificate Chain) Header Parameter</a>
    */
+  // @JsonIgnore needed because of:
+  // https://github.com/FasterXML/jackson-databind/issues/4413#issuecomment-1977989776
+  @JsonIgnore
   public Optional<List<X509Certificate>> getX5c() {
     return Optional.ofNullable(x5c);
   }


### PR DESCRIPTION
`@JsonSerialize(contentConverter = ...)` is incompatible with property type `Optional<List<T>>`, which is the detected serialization type because of the auto-detected getter, because `contentConverter` only descends one container level.

See: https://github.com/FasterXML/jackson-databind/issues/4413#issuecomment-1977989776

Fixes #350.