### PR TITLE
Drop slf4j-test from webauthn-server-attestation test dependencies

### DIFF
--- a/webauthn-server-attestation/build.gradle.kts
+++ b/webauthn-server-attestation/build.gradle.kts
@@ -47,13 +47,8 @@ dependencies {
   testImplementation("org.scalatest:scalatest_2.13")
   testImplementation("org.scalatestplus:junit-4-13_2.13")
   testImplementation("org.scalatestplus:scalacheck-1-16_2.13")
-  testImplementation("uk.org.lidalia:slf4j-test")
 
-  testImplementation("org.slf4j:slf4j-api") {
-    version {
-      strictly("[1.7.25,1.8-a)") // Pre-1.8 version required by slf4j-test
-    }
-  }
+  testImplementation("org.slf4j:slf4j-api")
 }
 
 val integrationTest = task<Test>("integrationTest") {

--- a/webauthn-server-attestation/src/test/resources/slf4jtest.properties
+++ b/webauthn-server-attestation/src/test/resources/slf4jtest.properties
@@ -1,1 +1,0 @@
-print.level=DEBUG


### PR DESCRIPTION
This prevents the unit test XML reports from containing large stdout logs which are not used for anything but crash the default settings of EnricoMi/publish-unit-test-result-action@v2 .