### PR TITLE
Reference Google style guide in developer docs

### DIFF
--- a/doc/development.md
+++ b/doc/development.md
@@ -44,8 +44,9 @@ In case of disagreement on code style, defer to the style guide.
 Setup for publishing
 ---
 
-To enable publishing to Maven Central via Sonatype Nexus, set
-`yubicoPublish=true` in `$HOME/.gradle/gradle.properties` and add your Sonatype
+To enable publishing to Maven Central via Sonatype Nexus,
+[generate a user token](https://central.sonatype.org/publish/generate-token/).
+Set `yubicoPublish=true` in `$HOME/.gradle/gradle.properties` and add your token
 username and password. Example:
 
 ```properties

--- a/doc/development.md
+++ b/doc/development.md
@@ -30,6 +30,16 @@ Use `./gradlew spotlessApply` to run the automatic code formatter.
 You can also run it in continuous mode as `./gradlew --continuous spotlessApply`
 to reformat whenever a file changes.
 
+We mean to follow the [Google Java Style Guide](https://google.github.io/styleguide/javaguide.html),
+but do not enforce it comprehensively (apart from what the automatic formatter does).
+Take particular note of the rules:
+
+- [3.3.1 No wildcard imports](https://google.github.io/styleguide/javaguide.html#s3.3.1-wildcard-imports)
+- [5.3 Camel case: defined](https://google.github.io/styleguide/javaguide.html#s5.3-camel-case)
+  (`XmlHttpRequest` and `requestId`, not `XMLHTTPRequest` and `requestID`)
+
+In case of disagreement on code style, defer to the style guide.
+
 
 Setup for publishing
 ---


### PR DESCRIPTION
Prompted by https://github.com/Yubico/java-webauthn-server/pull/363#discussion_r1673998882

This has been undocumented but is the de facto style we use (mostly, probably), especially since using google-java-format.