### PR TITLE
Fix crash on unknown COSEAlgorithmIdentifier in FIDO MDS

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,14 @@
+== Version 2.5.4 (unreleased) ==
+
+`webauthn-server-attestation`:
+
+Fixes:
+
+* `AuthenticatorGetInfo.algorithms` now silently ignores unknown
+  `COSEAlgorithmIdentifier` and `PublicKeyCredentialType` values instead of
+  rejecting the MDS BLOB.
+
+
 == Version 2.5.3 ==
 
 `webauthn-server-attestation`:


### PR DESCRIPTION
Fixes #387.

I chose to do it this way instead of adding a `COSEAlgorithmIdentifier` constant primarily because doing that would advertise support for verifying `PS256` signatures, which is not included in this change. This will also be more robust to future MDS entries adding more unknown algorithm values.