### PR TITLE
Remove credProps.authenticatorDisplayName

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -58,7 +58,6 @@ New features:
     version increase.
  ** NOTE: Experimental features may receive breaking changes without a major
     version increase.
-* (Experimental) Added `credProps` extension to assertion extension outputs.
 
 
 == Version 2.5.4 ==

--- a/NEWS
+++ b/NEWS
@@ -56,7 +56,6 @@ New features:
 * (Experimental) Added property `RegisteredCredential.transports`.
  ** NOTE: Experimental features may receive breaking changes without a major
     version increase.
-* (Experimental) Added property `credProps.authenticatorDisplayName`.
  ** NOTE: Experimental features may receive breaking changes without a major
     version increase.
 * (Experimental) Added `credProps` extension to assertion extension outputs.

--- a/webauthn-server-core/src/main/java/com/yubico/webauthn/AssertionResult.java
+++ b/webauthn-server-core/src/main/java/com/yubico/webauthn/AssertionResult.java
@@ -35,7 +35,6 @@ import com.yubico.webauthn.data.AuthenticatorDataFlags;
 import com.yubico.webauthn.data.AuthenticatorResponse;
 import com.yubico.webauthn.data.ByteArray;
 import com.yubico.webauthn.data.ClientAssertionExtensionOutputs;
-import com.yubico.webauthn.data.Extensions;
 import com.yubico.webauthn.data.PublicKeyCredential;
 import com.yubico.webauthn.data.PublicKeyCredentialRequestOptions;
 import com.yubico.webauthn.data.UserIdentity;
@@ -281,34 +280,5 @@ public class AssertionResult {
   public Optional<AuthenticatorAssertionExtensionOutputs> getAuthenticatorExtensionOutputs() {
     return AuthenticatorAssertionExtensionOutputs.fromAuthenticatorData(
         credentialResponse.getResponse().getParsedAuthenticatorData());
-  }
-
-  /**
-   * Retrieve a suitable nickname for this credential, if one is available. This MAY differ from
-   * {@link RegistrationResult#getAuthenticatorDisplayName() the value returned during
-   * registration}, if any. In that case the application may want to offer the user to update the
-   * previously stored value, if any.
-   *
-   * <p>This returns the <code>authenticatorDisplayName</code> output from the <a
-   * href="https://w3c.github.io/webauthn/#sctn-authenticator-credential-properties-extension">
-   * <code>credProps</code></a> extension.
-   *
-   * @return A user-chosen or vendor-default display name for the credential, if available.
-   *     Otherwise empty.
-   * @see <a
-   *     href="https://w3c.github.io/webauthn/#dom-credentialpropertiesoutput-authenticatordisplayname">
-   *     <code>authenticatorDisplayName</code> in §10.1.3. Credential Properties Extension
-   *     (credProps)</a>
-   * @see RegistrationResult#getAuthenticatorDisplayName()
-   * @see Extensions.CredentialProperties.CredentialPropertiesOutput#getAuthenticatorDisplayName()
-   * @deprecated EXPERIMENTAL: This feature is from a not yet mature standard; it could change as
-   *     the standard matures.
-   */
-  @JsonIgnore
-  @Deprecated
-  public Optional<String> getAuthenticatorDisplayName() {
-    return getClientExtensionOutputs()
-        .flatMap(outputs -> outputs.getCredProps())
-        .flatMap(credProps -> credProps.getAuthenticatorDisplayName());
   }
 }

--- a/webauthn-server-core/src/main/java/com/yubico/webauthn/AssertionResultV2.java
+++ b/webauthn-server-core/src/main/java/com/yubico/webauthn/AssertionResultV2.java
@@ -35,7 +35,6 @@ import com.yubico.webauthn.data.AuthenticatorDataFlags;
 import com.yubico.webauthn.data.AuthenticatorResponse;
 import com.yubico.webauthn.data.ByteArray;
 import com.yubico.webauthn.data.ClientAssertionExtensionOutputs;
-import com.yubico.webauthn.data.Extensions;
 import com.yubico.webauthn.data.PublicKeyCredential;
 import java.util.Optional;
 import lombok.AccessLevel;
@@ -243,34 +242,5 @@ public class AssertionResultV2<C extends CredentialRecord> {
   public Optional<AuthenticatorAssertionExtensionOutputs> getAuthenticatorExtensionOutputs() {
     return AuthenticatorAssertionExtensionOutputs.fromAuthenticatorData(
         credentialResponse.getResponse().getParsedAuthenticatorData());
-  }
-
-  /**
-   * Retrieve a suitable nickname for this credential, if one is available. This MAY differ from
-   * {@link RegistrationResult#getAuthenticatorDisplayName() the value returned during
-   * registration}, if any. In that case the application may want to offer the user to update the
-   * previously stored value, if any.
-   *
-   * <p>This returns the <code>authenticatorDisplayName</code> output from the <a
-   * href="https://w3c.github.io/webauthn/#sctn-authenticator-credential-properties-extension">
-   * <code>credProps</code></a> extension.
-   *
-   * @return A user-chosen or vendor-default display name for the credential, if available.
-   *     Otherwise empty.
-   * @see <a
-   *     href="https://w3c.github.io/webauthn/#dom-credentialpropertiesoutput-authenticatordisplayname">
-   *     <code>authenticatorDisplayName</code> in §10.1.3. Credential Properties Extension
-   *     (credProps)</a>
-   * @see RegistrationResult#getAuthenticatorDisplayName()
-   * @see Extensions.CredentialProperties.CredentialPropertiesOutput#getAuthenticatorDisplayName()
-   * @deprecated EXPERIMENTAL: This feature is from a not yet mature standard; it could change as
-   *     the standard matures.
-   */
-  @JsonIgnore
-  @Deprecated
-  public Optional<String> getAuthenticatorDisplayName() {
-    return getClientExtensionOutputs()
-        .flatMap(outputs -> outputs.getCredProps())
-        .flatMap(credProps -> credProps.getAuthenticatorDisplayName());
   }
 }

--- a/webauthn-server-core/src/main/java/com/yubico/webauthn/RegistrationResult.java
+++ b/webauthn-server-core/src/main/java/com/yubico/webauthn/RegistrationResult.java
@@ -39,7 +39,6 @@ import com.yubico.webauthn.data.AuthenticatorRegistrationExtensionOutputs;
 import com.yubico.webauthn.data.AuthenticatorResponse;
 import com.yubico.webauthn.data.ByteArray;
 import com.yubico.webauthn.data.ClientRegistrationExtensionOutputs;
-import com.yubico.webauthn.data.Extensions;
 import com.yubico.webauthn.data.PublicKeyCredential;
 import com.yubico.webauthn.data.PublicKeyCredentialDescriptor;
 import java.io.IOException;
@@ -366,33 +365,6 @@ public class RegistrationResult {
     return getClientExtensionOutputs()
         .flatMap(outputs -> outputs.getCredProps())
         .flatMap(credProps -> credProps.getRk());
-  }
-
-  /**
-   * Retrieve a suitable nickname for this credential, if one is available.
-   *
-   * <p>This returns the <code>authenticatorDisplayName</code> output from the <a
-   * href="https://w3c.github.io/webauthn/#sctn-authenticator-credential-properties-extension">
-   * <code>credProps</code></a> extension.
-   *
-   * @return A user-chosen or vendor-default display name for the credential, if available.
-   *     Otherwise empty.
-   * @see <a
-   *     href="https://w3c.github.io/webauthn/#dom-credentialpropertiesoutput-authenticatordisplayname">
-   *     <code>authenticatorDisplayName</code> in §10.1.3. Credential Properties Extension
-   *     (credProps)</a>
-   * @see AssertionResult#getAuthenticatorDisplayName()
-   * @see AssertionResultV2#getAuthenticatorDisplayName()
-   * @see Extensions.CredentialProperties.CredentialPropertiesOutput#getAuthenticatorDisplayName()
-   * @deprecated EXPERIMENTAL: This feature is from a not yet mature standard; it could change as
-   *     the standard matures.
-   */
-  @JsonIgnore
-  @Deprecated
-  public Optional<String> getAuthenticatorDisplayName() {
-    return getClientExtensionOutputs()
-        .flatMap(outputs -> outputs.getCredProps())
-        .flatMap(credProps -> credProps.getAuthenticatorDisplayName());
   }
 
   /**

--- a/webauthn-server-core/src/main/java/com/yubico/webauthn/data/ClientAssertionExtensionOutputs.java
+++ b/webauthn-server-core/src/main/java/com/yubico/webauthn/data/ClientAssertionExtensionOutputs.java
@@ -64,18 +64,13 @@ public class ClientAssertionExtensionOutputs implements ClientExtensionOutputs {
    */
   private final Boolean appid;
 
-  private final Extensions.CredentialProperties.CredentialPropertiesOutput credProps;
-
   private final Extensions.LargeBlob.LargeBlobAuthenticationOutput largeBlob;
 
   @JsonCreator
   private ClientAssertionExtensionOutputs(
       @JsonProperty("appid") Boolean appid,
-      @JsonProperty("credProps")
-          Extensions.CredentialProperties.CredentialPropertiesOutput credProps,
       @JsonProperty("largeBlob") Extensions.LargeBlob.LargeBlobAuthenticationOutput largeBlob) {
     this.appid = appid;
-    this.credProps = credProps;
     this.largeBlob = largeBlob;
   }
 
@@ -85,9 +80,6 @@ public class ClientAssertionExtensionOutputs implements ClientExtensionOutputs {
     HashSet<String> ids = new HashSet<>();
     if (appid != null) {
       ids.add(Extensions.Appid.EXTENSION_ID);
-    }
-    if (credProps != null) {
-      ids.add(Extensions.CredentialProperties.EXTENSION_ID);
     }
     if (largeBlob != null) {
       ids.add(Extensions.LargeBlob.EXTENSION_ID);
@@ -106,24 +98,6 @@ public class ClientAssertionExtensionOutputs implements ClientExtensionOutputs {
    */
   public Optional<Boolean> getAppid() {
     return Optional.ofNullable(appid);
-  }
-
-  /**
-   * The extension output for the Credential Properties Extension (<code>credProps</code>), if any.
-   *
-   * <p>This value MAY be present but have all members empty if the extension was successfully
-   * processed but no credential properties could be determined.
-   *
-   * @see com.yubico.webauthn.data.Extensions.CredentialProperties.CredentialPropertiesOutput
-   * @see <a
-   *     href="https://www.w3.org/TR/2021/REC-webauthn-2-20210408/#sctn-authenticator-credential-properties-extension">§10.4.
-   *     Credential Properties Extension (credProps)</a>
-   * @deprecated EXPERIMENTAL: This feature is from a not yet mature standard; it could change as
-   *     the standard matures.
-   */
-  @Deprecated
-  public Optional<Extensions.CredentialProperties.CredentialPropertiesOutput> getCredProps() {
-    return Optional.ofNullable(credProps);
   }
 
   /**

--- a/webauthn-server-core/src/main/java/com/yubico/webauthn/data/Extensions.java
+++ b/webauthn-server-core/src/main/java/com/yubico/webauthn/data/Extensions.java
@@ -6,9 +6,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonValue;
 import com.upokecenter.cbor.CBORObject;
 import com.upokecenter.cbor.CBORType;
-import com.yubico.webauthn.AssertionResult;
-import com.yubico.webauthn.AssertionResultV2;
-import com.yubico.webauthn.RegistrationResult;
 import com.yubico.webauthn.StartRegistrationOptions;
 import com.yubico.webauthn.extension.uvm.KeyProtectionType;
 import com.yubico.webauthn.extension.uvm.MatcherProtectionType;
@@ -74,15 +71,9 @@ public class Extensions {
       @JsonProperty("rk")
       private final Boolean rk;
 
-      @JsonProperty("authenticatorDisplayName")
-      private final String authenticatorDisplayName;
-
       @JsonCreator
-      private CredentialPropertiesOutput(
-          @JsonProperty("rk") Boolean rk,
-          @JsonProperty("authenticatorDisplayName") String authenticatorDisplayName) {
+      private CredentialPropertiesOutput(@JsonProperty("rk") Boolean rk) {
         this.rk = rk;
-        this.authenticatorDisplayName = authenticatorDisplayName;
       }
 
       /**
@@ -113,34 +104,6 @@ public class Extensions {
        */
       public Optional<Boolean> getRk() {
         return Optional.ofNullable(rk);
-      }
-
-      /**
-       * This OPTIONAL property is a human-palatable description of the credential's managing
-       * authenticator, chosen by the user.
-       *
-       * <p>If the application supports setting "nicknames" for registered credentials, then this
-       * value may be a suitable default value for such a nickname.
-       *
-       * <p>In an authentication ceremony, if this value is different from the stored nickname, then
-       * the application may want to offer the user to update the stored nickname to match this
-       * value.
-       *
-       * @return A user-chosen or vendor-default display name for the credential, if available.
-       *     Otherwise empty.
-       * @see <a
-       *     href="https://w3c.github.io/webauthn/#dom-credentialpropertiesoutput-authenticatordisplayname">
-       *     <code>authenticatorDisplayName</code> in §10.1.3. Credential Properties Extension
-       *     (credProps)</a>
-       * @see RegistrationResult#getAuthenticatorDisplayName()
-       * @see AssertionResult#getAuthenticatorDisplayName()
-       * @see AssertionResultV2#getAuthenticatorDisplayName()
-       * @deprecated EXPERIMENTAL: This feature is from a not yet mature standard; it could change
-       *     as the standard matures.
-       */
-      @Deprecated
-      public Optional<String> getAuthenticatorDisplayName() {
-        return Optional.ofNullable(authenticatorDisplayName);
       }
     }
   }

--- a/webauthn-server-core/src/test/scala/com/yubico/webauthn/RelyingPartyAssertionSpec.scala
+++ b/webauthn-server-core/src/test/scala/com/yubico/webauthn/RelyingPartyAssertionSpec.scala
@@ -38,7 +38,6 @@ import com.yubico.webauthn.data.AuthenticatorTransport
 import com.yubico.webauthn.data.ByteArray
 import com.yubico.webauthn.data.ClientAssertionExtensionOutputs
 import com.yubico.webauthn.data.CollectedClientData
-import com.yubico.webauthn.data.Extensions.CredentialProperties.CredentialPropertiesOutput
 import com.yubico.webauthn.data.Extensions.LargeBlob.LargeBlobAuthenticationInput
 import com.yubico.webauthn.data.Extensions.LargeBlob.LargeBlobAuthenticationOutput
 import com.yubico.webauthn.data.Extensions.Uvm.UvmEntry
@@ -2844,55 +2843,6 @@ class RelyingPartyAssertionSpec
               result.getAuthenticatorAttachment should equal(
                 pkc.getAuthenticatorAttachment
               )
-            }
-          }
-
-          describe("exposes the credProps.authenticatorDisplayName extension output as getAuthenticatorDisplayName()") {
-            val pkcTemplate =
-              TestAuthenticator.createAssertion(
-                challenge =
-                  request.getPublicKeyCredentialRequestOptions.getChallenge,
-                credentialKey = credentialKeypair,
-                credentialId = credential.getId,
-              )
-
-            it("""when set to "hej".""") {
-              val pkc = pkcTemplate.toBuilder
-                .clientExtensionResults(
-                  pkcTemplate.getClientExtensionResults.toBuilder
-                    .credProps(
-                      CredentialPropertiesOutput
-                        .builder()
-                        .authenticatorDisplayName("hej")
-                        .build()
-                    )
-                    .build()
-                )
-                .build()
-              val result = rp.finishAssertion(
-                FinishAssertionOptions
-                  .builder()
-                  .request(request)
-                  .response(pkc)
-                  .build()
-              )
-
-              result.getAuthenticatorDisplayName.toScala should equal(
-                Some("hej")
-              )
-            }
-
-            it("when not available.") {
-              val pkc = pkcTemplate
-              val result = rp.finishAssertion(
-                FinishAssertionOptions
-                  .builder()
-                  .request(request)
-                  .response(pkc)
-                  .build()
-              )
-
-              result.getAuthenticatorDisplayName.toScala should equal(None)
             }
           }
         }

--- a/webauthn-server-core/src/test/scala/com/yubico/webauthn/RelyingPartyRegistrationSpec.scala
+++ b/webauthn-server-core/src/test/scala/com/yubico/webauthn/RelyingPartyRegistrationSpec.scala
@@ -266,7 +266,6 @@ class RelyingPartyRegistrationSpec
                   "org.example.foo": "bar",
                   "credProps": {
                     "rk": false,
-                    "authenticatorDisplayName": "My passkey",
                     "unknownProperty": ["unknown-value"]
                   }
                 }
@@ -4286,51 +4285,6 @@ class RelyingPartyRegistrationSpec
           )
 
           result.isDiscoverable.toScala should equal(None)
-        }
-      }
-
-      describe("expose the credProps.authenticatorDisplayName extension output as RegistrationResult.getAuthenticatorDisplayName()") {
-        val testDataBase = RegistrationTestData.Packed.BasicAttestation
-        val testData = testDataBase.copy(requestedExtensions =
-          testDataBase.request.getExtensions.toBuilder.credProps().build()
-        )
-
-        it("""when set to "hej".""") {
-          val result = rp.finishRegistration(
-            FinishRegistrationOptions
-              .builder()
-              .request(testData.request)
-              .response(
-                testData.response.toBuilder
-                  .clientExtensionResults(
-                    ClientRegistrationExtensionOutputs
-                      .builder()
-                      .credProps(
-                        CredentialPropertiesOutput
-                          .builder()
-                          .authenticatorDisplayName("hej")
-                          .build()
-                      )
-                      .build()
-                  )
-                  .build()
-              )
-              .build()
-          )
-
-          result.getAuthenticatorDisplayName.toScala should equal(Some("hej"))
-        }
-
-        it("when not available.") {
-          val result = rp.finishRegistration(
-            FinishRegistrationOptions
-              .builder()
-              .request(testData.request)
-              .response(testData.response)
-              .build()
-          )
-
-          result.getAuthenticatorDisplayName.toScala should equal(None)
         }
       }
 

--- a/webauthn-server-core/src/test/scala/com/yubico/webauthn/RelyingPartyV2AssertionSpec.scala
+++ b/webauthn-server-core/src/test/scala/com/yubico/webauthn/RelyingPartyV2AssertionSpec.scala
@@ -38,7 +38,6 @@ import com.yubico.webauthn.data.AuthenticatorTransport
 import com.yubico.webauthn.data.ByteArray
 import com.yubico.webauthn.data.ClientAssertionExtensionOutputs
 import com.yubico.webauthn.data.CollectedClientData
-import com.yubico.webauthn.data.Extensions.CredentialProperties.CredentialPropertiesOutput
 import com.yubico.webauthn.data.Extensions.LargeBlob.LargeBlobAuthenticationInput
 import com.yubico.webauthn.data.Extensions.LargeBlob.LargeBlobAuthenticationOutput
 import com.yubico.webauthn.data.Extensions.Uvm.UvmEntry
@@ -2919,55 +2918,6 @@ class RelyingPartyV2AssertionSpec
               result.getAuthenticatorAttachment should equal(
                 pkc.getAuthenticatorAttachment
               )
-            }
-          }
-
-          describe("exposes the credProps.authenticatorDisplayName extension output as getAuthenticatorDisplayName()") {
-            val pkcTemplate =
-              TestAuthenticator.createAssertion(
-                challenge =
-                  request.getPublicKeyCredentialRequestOptions.getChallenge,
-                credentialKey = credentialKeypair,
-                credentialId = credential.getId,
-              )
-
-            it("""when set to "hej".""") {
-              val pkc = pkcTemplate.toBuilder
-                .clientExtensionResults(
-                  pkcTemplate.getClientExtensionResults.toBuilder
-                    .credProps(
-                      CredentialPropertiesOutput
-                        .builder()
-                        .authenticatorDisplayName("hej")
-                        .build()
-                    )
-                    .build()
-                )
-                .build()
-              val result = rp.finishAssertion(
-                FinishAssertionOptions
-                  .builder()
-                  .request(request)
-                  .response(pkc)
-                  .build()
-              )
-
-              result.getAuthenticatorDisplayName.toScala should equal(
-                Some("hej")
-              )
-            }
-
-            it("when not available.") {
-              val pkc = pkcTemplate
-              val result = rp.finishAssertion(
-                FinishAssertionOptions
-                  .builder()
-                  .request(request)
-                  .response(pkc)
-                  .build()
-              )
-
-              result.getAuthenticatorDisplayName.toScala should equal(None)
             }
           }
         }

--- a/webauthn-server-core/src/test/scala/com/yubico/webauthn/data/Generators.scala
+++ b/webauthn-server-core/src/test/scala/com/yubico/webauthn/data/Generators.scala
@@ -868,11 +868,9 @@ object Generators {
       def credentialPropertiesOutput: Gen[CredentialPropertiesOutput] =
         for {
           rk <- arbitrary[Option[Boolean]]
-          authenticatorDisplayName <- arbitrary[Option[String]]
         } yield {
           val b = CredentialPropertiesOutput.builder()
           rk.foreach(b.rk(_))
-          authenticatorDisplayName.foreach(b.authenticatorDisplayName)
           b.build()
         }
     }


### PR DESCRIPTION
`credProps.authenticatorDisplayName` was [removed from WebAuthn](https://github.com/w3c/webauthn/issues/2187), so let's remove it here too.