### PR TITLE
Remove self-contradicting test assertion

### DIFF
--- a/webauthn-server-core/src/test/scala/com/yubico/webauthn/RelyingPartyRegistrationSpec.scala
+++ b/webauthn-server-core/src/test/scala/com/yubico/webauthn/RelyingPartyRegistrationSpec.scala
@@ -2051,13 +2051,6 @@ class RelyingPartyRegistrationSpec
                     IllegalArgumentException
                   ]
 
-                  val goodResult = Try(
-                    verifier.verifyX5cRequirements(badCert, testDataBase.aaguid)
-                  )
-
-                  goodResult shouldBe a[Failure[_]]
-                  goodResult.failed.get shouldBe an[IllegalArgumentException]
-
                   verifier.verifyX5cRequirements(
                     testDataBase.packedAttestationCert,
                     testDataBase.aaguid,


### PR DESCRIPTION
This variable is named `goodResult`, implying that the verification should be a success, but the assertion checks that the verification should be a failure. The arguments to `verifyX5cRequirements` are the same as above for the `result` variable with `badCert`. This code is probably a copy-paste error.