### PR TITLE
Fix parsing SupportedCtapOptions from empty JSON object

### DIFF
--- a/webauthn-server-attestation/src/main/java/com/yubico/fido/metadata/SupportedCtapOptions.java
+++ b/webauthn-server-attestation/src/main/java/com/yubico/fido/metadata/SupportedCtapOptions.java
@@ -24,30 +24,14 @@ public class SupportedCtapOptions {
    *     href="https://fidoalliance.org/specs/fido-v2.1-ps-20210615/fido-client-to-authenticator-protocol-v2.1-ps-20210615.html#authenticatorGetInfo">Client
    *     to Authenticator Protocol (CTAP) §6.4. authenticatorGetInfo (0x04)</a>
    */
-  @Builder.Default boolean plat = false;
+  boolean plat;
 
   /**
    * @see <a
    *     href="https://fidoalliance.org/specs/fido-v2.1-ps-20210615/fido-client-to-authenticator-protocol-v2.1-ps-20210615.html#authenticatorGetInfo">Client
    *     to Authenticator Protocol (CTAP) §6.4. authenticatorGetInfo (0x04)</a>
    */
-  @Builder.Default boolean rk = false;
-
-  /**
-   * @see <a
-   *     href="https://fidoalliance.org/specs/fido-v2.1-ps-20210615/fido-client-to-authenticator-protocol-v2.1-ps-20210615.html#authenticatorGetInfo">Client
-   *     to Authenticator Protocol (CTAP) §6.4. authenticatorGetInfo (0x04)</a>
-   */
-  @JsonInclude(JsonInclude.Include.NON_DEFAULT)
-  @Builder.Default
-  boolean clientPin = false;
-
-  /**
-   * @see <a
-   *     href="https://fidoalliance.org/specs/fido-v2.1-ps-20210615/fido-client-to-authenticator-protocol-v2.1-ps-20210615.html#authenticatorGetInfo">Client
-   *     to Authenticator Protocol (CTAP) §6.4. authenticatorGetInfo (0x04)</a>
-   */
-  @Builder.Default boolean up = false;
+  boolean rk;
 
   /**
    * @see <a
@@ -55,8 +39,22 @@ public class SupportedCtapOptions {
    *     to Authenticator Protocol (CTAP) §6.4. authenticatorGetInfo (0x04)</a>
    */
   @JsonInclude(JsonInclude.Include.NON_DEFAULT)
-  @Builder.Default
-  boolean uv = false;
+  boolean clientPin;
+
+  /**
+   * @see <a
+   *     href="https://fidoalliance.org/specs/fido-v2.1-ps-20210615/fido-client-to-authenticator-protocol-v2.1-ps-20210615.html#authenticatorGetInfo">Client
+   *     to Authenticator Protocol (CTAP) §6.4. authenticatorGetInfo (0x04)</a>
+   */
+  boolean up;
+
+  /**
+   * @see <a
+   *     href="https://fidoalliance.org/specs/fido-v2.1-ps-20210615/fido-client-to-authenticator-protocol-v2.1-ps-20210615.html#authenticatorGetInfo">Client
+   *     to Authenticator Protocol (CTAP) §6.4. authenticatorGetInfo (0x04)</a>
+   */
+  @JsonInclude(JsonInclude.Include.NON_DEFAULT)
+  boolean uv;
 
   /**
    * @see <a
@@ -64,31 +62,21 @@ public class SupportedCtapOptions {
    *     to Authenticator Protocol (CTAP) §6.4. authenticatorGetInfo (0x04)</a>
    */
   @JsonAlias("uvToken")
-  @Builder.Default
-  boolean pinUvAuthToken = false;
+  boolean pinUvAuthToken;
 
   /**
    * @see <a
    *     href="https://fidoalliance.org/specs/fido-v2.1-ps-20210615/fido-client-to-authenticator-protocol-v2.1-ps-20210615.html#authenticatorGetInfo">Client
    *     to Authenticator Protocol (CTAP) §6.4. authenticatorGetInfo (0x04)</a>
    */
-  @Builder.Default boolean noMcGaPermissionsWithClientPin = false;
+  boolean noMcGaPermissionsWithClientPin;
 
   /**
    * @see <a
    *     href="https://fidoalliance.org/specs/fido-v2.1-ps-20210615/fido-client-to-authenticator-protocol-v2.1-ps-20210615.html#authenticatorGetInfo">Client
    *     to Authenticator Protocol (CTAP) §6.4. authenticatorGetInfo (0x04)</a>
    */
-  @Builder.Default boolean largeBlobs = false;
-
-  /**
-   * @see <a
-   *     href="https://fidoalliance.org/specs/fido-v2.1-ps-20210615/fido-client-to-authenticator-protocol-v2.1-ps-20210615.html#authenticatorGetInfo">Client
-   *     to Authenticator Protocol (CTAP) §6.4. authenticatorGetInfo (0x04)</a>
-   */
-  @JsonInclude(JsonInclude.Include.NON_DEFAULT)
-  @Builder.Default
-  boolean ep = false;
+  boolean largeBlobs;
 
   /**
    * @see <a
@@ -96,8 +84,7 @@ public class SupportedCtapOptions {
    *     to Authenticator Protocol (CTAP) §6.4. authenticatorGetInfo (0x04)</a>
    */
   @JsonInclude(JsonInclude.Include.NON_DEFAULT)
-  @Builder.Default
-  boolean bioEnroll = false;
+  boolean ep;
 
   /**
    * @see <a
@@ -105,15 +92,22 @@ public class SupportedCtapOptions {
    *     to Authenticator Protocol (CTAP) §6.4. authenticatorGetInfo (0x04)</a>
    */
   @JsonInclude(JsonInclude.Include.NON_DEFAULT)
-  @Builder.Default
-  boolean userVerificationMgmtPreview = false;
+  boolean bioEnroll;
 
   /**
    * @see <a
    *     href="https://fidoalliance.org/specs/fido-v2.1-ps-20210615/fido-client-to-authenticator-protocol-v2.1-ps-20210615.html#authenticatorGetInfo">Client
    *     to Authenticator Protocol (CTAP) §6.4. authenticatorGetInfo (0x04)</a>
    */
-  @Builder.Default boolean uvBioEnroll = false;
+  @JsonInclude(JsonInclude.Include.NON_DEFAULT)
+  boolean userVerificationMgmtPreview;
+
+  /**
+   * @see <a
+   *     href="https://fidoalliance.org/specs/fido-v2.1-ps-20210615/fido-client-to-authenticator-protocol-v2.1-ps-20210615.html#authenticatorGetInfo">Client
+   *     to Authenticator Protocol (CTAP) §6.4. authenticatorGetInfo (0x04)</a>
+   */
+  boolean uvBioEnroll;
 
   /**
    * @see <a
@@ -121,45 +115,21 @@ public class SupportedCtapOptions {
    *     to Authenticator Protocol (CTAP) §6.4. authenticatorGetInfo (0x04)</a>
    */
   @JsonAlias("config")
-  @Builder.Default
-  boolean authnrCfg = false;
+  boolean authnrCfg;
 
   /**
    * @see <a
    *     href="https://fidoalliance.org/specs/fido-v2.1-ps-20210615/fido-client-to-authenticator-protocol-v2.1-ps-20210615.html#authenticatorGetInfo">Client
    *     to Authenticator Protocol (CTAP) §6.4. authenticatorGetInfo (0x04)</a>
    */
-  @Builder.Default boolean uvAcfg = false;
+  boolean uvAcfg;
 
   /**
    * @see <a
    *     href="https://fidoalliance.org/specs/fido-v2.1-ps-20210615/fido-client-to-authenticator-protocol-v2.1-ps-20210615.html#authenticatorGetInfo">Client
    *     to Authenticator Protocol (CTAP) §6.4. authenticatorGetInfo (0x04)</a>
    */
-  @Builder.Default boolean credMgmt = false;
-
-  /**
-   * @see <a
-   *     href="https://fidoalliance.org/specs/fido-v2.1-ps-20210615/fido-client-to-authenticator-protocol-v2.1-ps-20210615.html#authenticatorGetInfo">Client
-   *     to Authenticator Protocol (CTAP) §6.4. authenticatorGetInfo (0x04)</a>
-   */
-  @JsonInclude(JsonInclude.Include.NON_DEFAULT)
-  @Builder.Default
-  boolean credentialMgmtPreview = false;
-
-  /**
-   * @see <a
-   *     href="https://fidoalliance.org/specs/fido-v2.1-ps-20210615/fido-client-to-authenticator-protocol-v2.1-ps-20210615.html#authenticatorGetInfo">Client
-   *     to Authenticator Protocol (CTAP) §6.4. authenticatorGetInfo (0x04)</a>
-   */
-  @Builder.Default boolean setMinPINLength = false;
-
-  /**
-   * @see <a
-   *     href="https://fidoalliance.org/specs/fido-v2.1-ps-20210615/fido-client-to-authenticator-protocol-v2.1-ps-20210615.html#authenticatorGetInfo">Client
-   *     to Authenticator Protocol (CTAP) §6.4. authenticatorGetInfo (0x04)</a>
-   */
-  @Builder.Default boolean makeCredUvNotRqd = false;
+  boolean credMgmt;
 
   /**
    * @see <a
@@ -167,8 +137,29 @@ public class SupportedCtapOptions {
    *     to Authenticator Protocol (CTAP) §6.4. authenticatorGetInfo (0x04)</a>
    */
   @JsonInclude(JsonInclude.Include.NON_DEFAULT)
-  @Builder.Default
-  boolean alwaysUv = false;
+  boolean credentialMgmtPreview;
+
+  /**
+   * @see <a
+   *     href="https://fidoalliance.org/specs/fido-v2.1-ps-20210615/fido-client-to-authenticator-protocol-v2.1-ps-20210615.html#authenticatorGetInfo">Client
+   *     to Authenticator Protocol (CTAP) §6.4. authenticatorGetInfo (0x04)</a>
+   */
+  boolean setMinPINLength;
+
+  /**
+   * @see <a
+   *     href="https://fidoalliance.org/specs/fido-v2.1-ps-20210615/fido-client-to-authenticator-protocol-v2.1-ps-20210615.html#authenticatorGetInfo">Client
+   *     to Authenticator Protocol (CTAP) §6.4. authenticatorGetInfo (0x04)</a>
+   */
+  boolean makeCredUvNotRqd;
+
+  /**
+   * @see <a
+   *     href="https://fidoalliance.org/specs/fido-v2.1-ps-20210615/fido-client-to-authenticator-protocol-v2.1-ps-20210615.html#authenticatorGetInfo">Client
+   *     to Authenticator Protocol (CTAP) §6.4. authenticatorGetInfo (0x04)</a>
+   */
+  @JsonInclude(JsonInclude.Include.NON_DEFAULT)
+  boolean alwaysUv;
 
   @JsonCreator
   private SupportedCtapOptions(

--- a/webauthn-server-attestation/src/main/java/com/yubico/fido/metadata/SupportedCtapOptions.java
+++ b/webauthn-server-attestation/src/main/java/com/yubico/fido/metadata/SupportedCtapOptions.java
@@ -61,7 +61,6 @@ public class SupportedCtapOptions {
    *     href="https://fidoalliance.org/specs/fido-v2.1-ps-20210615/fido-client-to-authenticator-protocol-v2.1-ps-20210615.html#authenticatorGetInfo">Client
    *     to Authenticator Protocol (CTAP) §6.4. authenticatorGetInfo (0x04)</a>
    */
-  @JsonAlias("uvToken")
   boolean pinUvAuthToken;
 
   /**
@@ -114,7 +113,6 @@ public class SupportedCtapOptions {
    *     href="https://fidoalliance.org/specs/fido-v2.1-ps-20210615/fido-client-to-authenticator-protocol-v2.1-ps-20210615.html#authenticatorGetInfo">Client
    *     to Authenticator Protocol (CTAP) §6.4. authenticatorGetInfo (0x04)</a>
    */
-  @JsonAlias("config")
   boolean authnrCfg;
 
   /**
@@ -168,14 +166,14 @@ public class SupportedCtapOptions {
       @JsonProperty("clientPin") Boolean clientPin,
       @JsonProperty("up") Boolean up,
       @JsonProperty("uv") Boolean uv,
-      @JsonProperty("pinUvAuthToken") Boolean pinUvAuthToken,
+      @JsonAlias("uvToken") @JsonProperty("pinUvAuthToken") Boolean pinUvAuthToken,
       @JsonProperty("noMcGaPermissionsWithClientPin") Boolean noMcGaPermissionsWithClientPin,
       @JsonProperty("largeBlobs") Boolean largeBlobs,
       @JsonProperty("ep") Boolean ep,
       @JsonProperty("bioEnroll") Boolean bioEnroll,
       @JsonProperty("userVerificationMgmtPreview") Boolean userVerificationMgmtPreview,
       @JsonProperty("uvBioEnroll") Boolean uvBioEnroll,
-      @JsonProperty("authnrCfg") Boolean authnrCfg,
+      @JsonAlias("config") @JsonProperty("authnrCfg") Boolean authnrCfg,
       @JsonProperty("uvAcfg") Boolean uvAcfg,
       @JsonProperty("credMgmt") Boolean credMgmt,
       @JsonProperty("credentialMgmtPreview") Boolean credentialMgmtPreview,

--- a/webauthn-server-attestation/src/main/java/com/yubico/fido/metadata/SupportedCtapOptions.java
+++ b/webauthn-server-attestation/src/main/java/com/yubico/fido/metadata/SupportedCtapOptions.java
@@ -2,10 +2,10 @@ package com.yubico.fido.metadata;
 
 import com.fasterxml.jackson.annotation.JsonAlias;
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Builder;
 import lombok.Value;
-import lombok.extern.jackson.Jacksonized;
 
 /**
  * A fixed-keys map of CTAP2 option names to Boolean values representing whether an authenticator
@@ -17,7 +17,6 @@ import lombok.extern.jackson.Jacksonized;
  */
 @Value
 @Builder
-@Jacksonized
 public class SupportedCtapOptions {
 
   /**
@@ -39,7 +38,9 @@ public class SupportedCtapOptions {
    *     href="https://fidoalliance.org/specs/fido-v2.1-ps-20210615/fido-client-to-authenticator-protocol-v2.1-ps-20210615.html#authenticatorGetInfo">Client
    *     to Authenticator Protocol (CTAP) §6.4. authenticatorGetInfo (0x04)</a>
    */
-  @Builder.Default boolean clientPin = false;
+  @JsonInclude(JsonInclude.Include.NON_DEFAULT)
+  @Builder.Default
+  boolean clientPin = false;
 
   /**
    * @see <a
@@ -53,7 +54,9 @@ public class SupportedCtapOptions {
    *     href="https://fidoalliance.org/specs/fido-v2.1-ps-20210615/fido-client-to-authenticator-protocol-v2.1-ps-20210615.html#authenticatorGetInfo">Client
    *     to Authenticator Protocol (CTAP) §6.4. authenticatorGetInfo (0x04)</a>
    */
-  @Builder.Default boolean uv = false;
+  @JsonInclude(JsonInclude.Include.NON_DEFAULT)
+  @Builder.Default
+  boolean uv = false;
 
   /**
    * @see <a
@@ -83,21 +86,27 @@ public class SupportedCtapOptions {
    *     href="https://fidoalliance.org/specs/fido-v2.1-ps-20210615/fido-client-to-authenticator-protocol-v2.1-ps-20210615.html#authenticatorGetInfo">Client
    *     to Authenticator Protocol (CTAP) §6.4. authenticatorGetInfo (0x04)</a>
    */
-  @Builder.Default boolean ep = false;
+  @JsonInclude(JsonInclude.Include.NON_DEFAULT)
+  @Builder.Default
+  boolean ep = false;
 
   /**
    * @see <a
    *     href="https://fidoalliance.org/specs/fido-v2.1-ps-20210615/fido-client-to-authenticator-protocol-v2.1-ps-20210615.html#authenticatorGetInfo">Client
    *     to Authenticator Protocol (CTAP) §6.4. authenticatorGetInfo (0x04)</a>
    */
-  @Builder.Default boolean bioEnroll = false;
+  @JsonInclude(JsonInclude.Include.NON_DEFAULT)
+  @Builder.Default
+  boolean bioEnroll = false;
 
   /**
    * @see <a
    *     href="https://fidoalliance.org/specs/fido-v2.1-ps-20210615/fido-client-to-authenticator-protocol-v2.1-ps-20210615.html#authenticatorGetInfo">Client
    *     to Authenticator Protocol (CTAP) §6.4. authenticatorGetInfo (0x04)</a>
    */
-  @Builder.Default boolean userVerificationMgmtPreview = false;
+  @JsonInclude(JsonInclude.Include.NON_DEFAULT)
+  @Builder.Default
+  boolean userVerificationMgmtPreview = false;
 
   /**
    * @see <a
@@ -134,7 +143,9 @@ public class SupportedCtapOptions {
    *     href="https://fidoalliance.org/specs/fido-v2.1-ps-20210615/fido-client-to-authenticator-protocol-v2.1-ps-20210615.html#authenticatorGetInfo">Client
    *     to Authenticator Protocol (CTAP) §6.4. authenticatorGetInfo (0x04)</a>
    */
-  @Builder.Default boolean credentialMgmtPreview = false;
+  @JsonInclude(JsonInclude.Include.NON_DEFAULT)
+  @Builder.Default
+  boolean credentialMgmtPreview = false;
 
   /**
    * @see <a
@@ -155,7 +166,9 @@ public class SupportedCtapOptions {
    *     href="https://fidoalliance.org/specs/fido-v2.1-ps-20210615/fido-client-to-authenticator-protocol-v2.1-ps-20210615.html#authenticatorGetInfo">Client
    *     to Authenticator Protocol (CTAP) §6.4. authenticatorGetInfo (0x04)</a>
    */
-  @Builder.Default boolean alwaysUv = false;
+  @JsonInclude(JsonInclude.Include.NON_DEFAULT)
+  @Builder.Default
+  boolean alwaysUv = false;
 
   @JsonCreator
   private SupportedCtapOptions(
@@ -178,10 +191,10 @@ public class SupportedCtapOptions {
       @JsonProperty("setMinPINLength") Boolean setMinPINLength,
       @JsonProperty("makeCredUvNotRqd") Boolean makeCredUvNotRqd,
       @JsonProperty("alwaysUv") Boolean alwaysUv) {
-    this.plat = plat;
-    this.rk = rk;
+    this.plat = Boolean.TRUE.equals(plat);
+    this.rk = Boolean.TRUE.equals(rk);
     this.clientPin = clientPin != null;
-    this.up = up;
+    this.up = Boolean.TRUE.equals(up);
     this.uv = uv != null;
     this.pinUvAuthToken = Boolean.TRUE.equals(pinUvAuthToken);
     this.noMcGaPermissionsWithClientPin = Boolean.TRUE.equals(noMcGaPermissionsWithClientPin);

--- a/webauthn-server-attestation/src/test/scala/com/yubico/fido/metadata/MetadataBlobSpec.scala
+++ b/webauthn-server-attestation/src/test/scala/com/yubico/fido/metadata/MetadataBlobSpec.scala
@@ -57,6 +57,31 @@ class MetadataBlobSpec
   }
 
   describe("SupportedCtapOptions") {
+    it("can be parsed from an empty JSON object.") {
+      val options = JacksonCodecs
+        .json()
+        .readValue("{}", classOf[SupportedCtapOptions])
+      options should not be null
+      options.isPlat should be(false)
+      options.isRk should be(false)
+      options.isUp should be(false)
+      options.isUv should be(false)
+      options.isPinUvAuthToken should be(false)
+      options.isNoMcGaPermissionsWithClientPin should be(false)
+      options.isLargeBlobs should be(false)
+      options.isEp should be(false)
+      options.isBioEnroll should be(false)
+      options.isUserVerificationMgmtPreview should be(false)
+      options.isUvBioEnroll should be(false)
+      options.isAuthnrCfg should be(false)
+      options.isUvAcfg should be(false)
+      options.isCredMgmt should be(false)
+      options.isCredentialMgmtPreview should be(false)
+      options.isSetMinPINLength should be(false)
+      options.isMakeCredUvNotRqd should be(false)
+      options.isAlwaysUv should be(false)
+    }
+
     it(
       "are structurally identical after multiple (de)serialization round-trips."
     ) {

--- a/webauthn-server-attestation/src/test/scala/com/yubico/fido/metadata/MetadataBlobSpec.scala
+++ b/webauthn-server-attestation/src/test/scala/com/yubico/fido/metadata/MetadataBlobSpec.scala
@@ -1,10 +1,16 @@
 package com.yubico.fido.metadata
 
+import com.yubico.fido.metadata.Generators.arbitrarySupportedCtapOptions
 import com.yubico.internal.util.JacksonCodecs
 import com.yubico.webauthn.data.ByteArray
+import org.scalacheck.Arbitrary
+import org.scalacheck.Gen
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
+
+import scala.jdk.CollectionConverters.SetHasAsScala
+import scala.jdk.OptionConverters.RichOptional
 
 class MetadataBlobSpec
     extends AnyFunSpec
@@ -50,4 +56,34 @@ class MetadataBlobSpec
     }
   }
 
+  describe("SupportedCtapOptions") {
+    it(
+      "are structurally identical after multiple (de)serialization round-trips."
+    ) {
+      val json = JacksonCodecs.json()
+      val blob = json
+        .readValue(
+          ByteArray
+            .fromBase64Url(FidoMds3Examples.BlobPayloadBase64url)
+            .getBytes,
+          classOf[MetadataBLOBPayload],
+        )
+      val blobOptions = blob.getEntries.asScala
+        .flatMap(entry => entry.getMetadataStatement.toScala)
+        .flatMap(statement => statement.getAuthenticatorGetInfo.toScala)
+        .flatMap(info => info.getOptions.toScala)
+      forAll(Gen.oneOf(Arbitrary.arbitrary, Gen.oneOf(blobOptions))) {
+        (options1: SupportedCtapOptions) =>
+          val encoded1 = json.writeValueAsBytes(options1)
+          val options2 = json.readValue(encoded1, classOf[SupportedCtapOptions])
+          val encoded2 = json.writeValueAsBytes(options2)
+          val options3 = json.readValue(encoded2, classOf[SupportedCtapOptions])
+
+          options2 should not be null
+          options2 should equal(options1)
+          options3 should not be null
+          options3 should equal(options1)
+      }
+    }
+  }
 }


### PR DESCRIPTION
(This would merge into #419, not into main)

Out of curiosity I tried what happens if you add a [test of parsing from an empty JSON object](https://github.com/Yubico/java-webauthn-server/pull/419#discussion_r2123762009), and it turned out to have wider repercussions than I expected :smile: it also interacts with the builder annotations in subtle ways. I've documented the process in detail in the first two commit descriptions. The last two are just cleanup and gathering related things closer together in the source code.