### PR TITLE
Fix regeneration of RegistrationTestData.assertion

### DIFF
--- a/webauthn-server-core/src/test/scala/com/yubico/webauthn/RegistrationTestData.scala
+++ b/webauthn-server-core/src/test/scala/com/yubico/webauthn/RegistrationTestData.scala
@@ -911,7 +911,7 @@ case class RegistrationTestData(
       val newValue =
         RegistrationTestData.from(credential, keypair, attestationCertChain)
       newValue.copy(
-        assertion = newValue.assertion.map(_.regenerate(newValue))
+        assertion = assertion.map(_.regenerate(newValue))
       )
     })
 


### PR DESCRIPTION
This was broken in commit 84746447188b64bb06245aacb04b2cb86a8cc14e because the `copy` method is no longer used, so `this.assertion` is no longer copied into `newValue`, and therefore `newValue.assertion` is always `None` in this `.map` call. The fix is to call `.map` on `this.assertion` (which is still the old value, which may be `Some`) instead of on `newValue.assertion` (which is always `None`).