### PR TITLE
Relax Guava dependency version constraint to allow major version 33

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,10 @@
+== Version 2.8.1 (unreleased) ==
+
+Changes:
+
+* Relaxed Guava dependency version constraint to include major version 33.
+
+
 == Version 2.8.0 ==
 
 `webauthn-server-core`:

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -22,7 +22,7 @@ dependencyResolutionManagement {
     versionCatalogs {
         create("constraintLibs") {
             library("cbor", "com.upokecenter:cbor:[4.5.1,5)")
-            library("guava", "com.google.guava:guava:[24.1.1,33)")
+            library("guava", "com.google.guava:guava:[24.1.1,34)")
             library("httpclient5", "org.apache.httpcomponents.client5", "httpclient5").version {
               strictly("[5.0.0,6)")
               reject("[5.4-alpha1,5.4.3)")


### PR DESCRIPTION
Fixes #448.

Before:
```
$ ./gradlew :webauthn-server-core:dependencies :webauthn-server-attestation:dependencies :yubico-util:dependencies | grep guava
|    +--- com.google.guava:guava:[24.1.1,33) -> 32.1.3-jre (c)
+--- com.google.guava:guava -> 32.1.3-jre
|    +--- com.google.guava:failureaccess:1.0.1
|    +--- com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava
+--- com.google.guava:guava (n)
+--- com.google.guava:guava FAILED
+--- com.google.guava:guava FAILED
|    +--- com.google.guava:guava:[24.1.1,33) -> 32.1.3-jre (c)
+--- com.google.guava:guava -> 32.1.3-jre
|    +--- com.google.guava:failureaccess:1.0.1
|    +--- com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava
|    +--- com.google.guava:guava:[24.1.1,33) -> 32.1.3-jre (c)
+--- com.google.guava:guava -> 32.1.3-jre
|    +--- com.google.guava:failureaccess:1.0.1
|    +--- com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava
|    +--- com.google.guava:guava:[24.1.1,33) -> 32.1.3-jre (c)
+--- com.google.guava:guava -> 32.1.3-jre
|    +--- com.google.guava:failureaccess:1.0.1
|    +--- com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava
|    +--- com.google.guava:guava:[24.1.1,33) -> 32.1.3-jre (c)
+--- com.google.guava:guava -> 32.1.3-jre
|    +--- com.google.guava:failureaccess:1.0.1
|    +--- com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava
|    |    +--- com.google.guava:guava:14.0.1 -> 32.1.3-jre (*)
|    +--- com.google.guava:guava:14.0.1 -> 32.1.3-jre (*)
|    |    \--- com.google.guava:guava:14.0.1 -> 32.1.3-jre (*)
|    +--- com.google.guava:guava:[24.1.1,33) -> 32.1.3-jre (c)
+--- com.google.guava:guava -> 32.1.3-jre
|    +--- com.google.guava:failureaccess:1.0.1
|    +--- com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava
|    |    +--- com.google.guava:guava:14.0.1 -> 32.1.3-jre (*)
|    +--- com.google.guava:guava:14.0.1 -> 32.1.3-jre (*)
|    |    \--- com.google.guava:guava:14.0.1 -> 32.1.3-jre (*)
|    +--- com.google.guava:guava:[24.1.1,33) -> 32.1.3-jre (c)
|    +--- com.google.guava:guava -> 32.1.3-jre
|    |    +--- com.google.guava:failureaccess:1.0.1
|    |    +--- com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava
     |    +--- com.google.guava:guava:14.0.1 -> 32.1.3-jre (*)
     +--- com.google.guava:guava:14.0.1 -> 32.1.3-jre (*)
     |    \--- com.google.guava:guava:14.0.1 -> 32.1.3-jre (*)
|    +--- com.google.guava:guava:[24.1.1,33) -> 32.1.3-jre (c)
|    +--- com.google.guava:guava -> 32.1.3-jre
|    |    +--- com.google.guava:failureaccess:1.0.1
|    |    +--- com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava
|    +--- com.google.guava:guava:[24.1.1,33) -> 32.1.3-jre (c)
|    +--- com.google.guava:guava -> 32.1.3-jre
|    |    +--- com.google.guava:failureaccess:1.0.1
|    |    +--- com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava
     |    +--- com.google.guava:guava:14.0.1 -> 32.1.3-jre (*)
     +--- com.google.guava:guava:14.0.1 -> 32.1.3-jre (*)
     |    \--- com.google.guava:guava:14.0.1 -> 32.1.3-jre (*)
```


After:
```
$ ./gradlew :webauthn-server-core:dependencies :webauthn-server-attestation:dependencies :yubico-util:dependencies | grep guava
|    +--- com.google.guava:guava:[24.1.1,34) -> 33.5.0-jre (c)
+--- com.google.guava:guava -> 33.5.0-jre
|    +--- com.google.guava:failureaccess:1.0.3
|    +--- com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava
+--- com.google.guava:guava (n)
+--- com.google.guava:guava FAILED
+--- com.google.guava:guava FAILED
|    +--- com.google.guava:guava:[24.1.1,34) -> 33.5.0-jre (c)
+--- com.google.guava:guava -> 33.5.0-jre
|    +--- com.google.guava:failureaccess:1.0.3
|    +--- com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava
|    +--- com.google.guava:guava:[24.1.1,34) -> 33.5.0-jre (c)
+--- com.google.guava:guava -> 33.5.0-jre
|    +--- com.google.guava:failureaccess:1.0.3
|    +--- com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava
|    +--- com.google.guava:guava:[24.1.1,34) -> 33.5.0-jre (c)
+--- com.google.guava:guava -> 33.5.0-jre
|    +--- com.google.guava:failureaccess:1.0.3
|    +--- com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava
|    +--- com.google.guava:guava:[24.1.1,34) -> 33.5.0-jre (c)
+--- com.google.guava:guava -> 33.5.0-jre
|    +--- com.google.guava:failureaccess:1.0.3
|    +--- com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava
|    |    +--- com.google.guava:guava:14.0.1 -> 33.5.0-jre (*)
|    +--- com.google.guava:guava:14.0.1 -> 33.5.0-jre (*)
|    |    \--- com.google.guava:guava:14.0.1 -> 33.5.0-jre (*)
|    +--- com.google.guava:guava:[24.1.1,34) -> 33.5.0-jre (c)
+--- com.google.guava:guava -> 33.5.0-jre
|    +--- com.google.guava:failureaccess:1.0.3
|    +--- com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava
|    |    +--- com.google.guava:guava:14.0.1 -> 33.5.0-jre (*)
|    +--- com.google.guava:guava:14.0.1 -> 33.5.0-jre (*)
|    |    \--- com.google.guava:guava:14.0.1 -> 33.5.0-jre (*)
|    +--- com.google.guava:guava:[24.1.1,34) -> 33.5.0-jre (c)
|    +--- com.google.guava:guava -> 33.5.0-jre
|    |    +--- com.google.guava:failureaccess:1.0.3
|    |    +--- com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava
     |    +--- com.google.guava:guava:14.0.1 -> 33.5.0-jre (*)
     +--- com.google.guava:guava:14.0.1 -> 33.5.0-jre (*)
     |    \--- com.google.guava:guava:14.0.1 -> 33.5.0-jre (*)
|    +--- com.google.guava:guava:[24.1.1,34) -> 33.5.0-jre (c)
|    +--- com.google.guava:guava -> 33.5.0-jre
|    |    +--- com.google.guava:failureaccess:1.0.3
|    |    +--- com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava
|    +--- com.google.guava:guava:[24.1.1,34) -> 33.5.0-jre (c)
|    +--- com.google.guava:guava -> 33.5.0-jre
|    |    +--- com.google.guava:failureaccess:1.0.3
|    |    +--- com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava
     |    +--- com.google.guava:guava:14.0.1 -> 33.5.0-jre (*)
     +--- com.google.guava:guava:14.0.1 -> 33.5.0-jre (*)
     |    \--- com.google.guava:guava:14.0.1 -> 33.5.0-jre (*)
```
