### PR TITLE
Test that Filters.notRetired() does not filter non-retired entries

### DIFF
--- a/webauthn-server-attestation/src/test/scala/com/yubico/fido/metadata/FidoMds3Spec.scala
+++ b/webauthn-server-attestation/src/test/scala/com/yubico/fido/metadata/FidoMds3Spec.scala
@@ -1038,18 +1038,6 @@ class FidoMds3Spec extends AnyFunSpec with Matchers {
   }
 
   describe("The notRetired filter") {
-    val attestationRoot = TestAuthenticator.generateAttestationCaCertificate()
-    val rootCertBase64 = new ByteArray(attestationRoot._1.getEncoded).getBase64
-
-    val (goodCert, _) = TestAuthenticator.generateAttestationCertificate(
-      name = new X500Name("CN=Good cert"),
-      caCertAndKey = Some(attestationRoot),
-    )
-
-    val goodCertKeyIdentifier = new ByteArray(
-      CertificateParser.computeSubjectKeyIdentifier(goodCert)
-    ).getHex
-
     val aaguidRetired =
       new AAGUID(ByteArray.fromHex("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"))
 
@@ -1062,16 +1050,13 @@ class FidoMds3Spec extends AnyFunSpec with Matchers {
         "entries": [
           {
             "aaguid": "${aaguidRetired.asGuidString()}",
-            "attestationCertificateKeyIdentifiers": ["${goodCertKeyIdentifier}"],
+            "attestationCertificateKeyIdentifiers": [],
             "metadataStatement": {
               "aaguid": "${aaguidRetired.asGuidString()}",
-              "attestationCertificateKeyIdentifiers": ["${goodCertKeyIdentifier}"],
               "authenticatorVersion": 1,
-              "attachmentHint" : ["internal"],
-              "attestationRootCertificates": ["${rootCertBase64}"],
+              "attestationRootCertificates": [],
               "attestationTypes" : ["basic_full"],
               "authenticationAlgorithms" : ["secp256r1_ecdsa_sha256_raw"],
-              "description" : "Test authenticator",
               "keyProtection" : ["software"],
               "matcherProtection" : ["software"],
               "protocolFamily" : "u2f",
@@ -1095,11 +1080,7 @@ class FidoMds3Spec extends AnyFunSpec with Matchers {
       val mds = FidoMetadataService.builder().useBlob(blob).build()
 
       mds
-        .findTrustRoots(
-          List(goodCert).asJava,
-          Some(aaguidRetired.asBytes).toJava,
-        )
-        .getTrustRoots
+        .findEntries(aaguidRetired)
         .asScala should not be empty
     }
 
@@ -1111,11 +1092,7 @@ class FidoMds3Spec extends AnyFunSpec with Matchers {
         .build()
 
       mds
-        .findTrustRoots(
-          List(goodCert).asJava,
-          Some(aaguidRetired.asBytes).toJava,
-        )
-        .getTrustRoots
+        .findEntries(aaguidRetired)
         .asScala shouldBe empty
     }
 

--- a/webauthn-server-attestation/src/test/scala/com/yubico/fido/metadata/FidoMds3Spec.scala
+++ b/webauthn-server-attestation/src/test/scala/com/yubico/fido/metadata/FidoMds3Spec.scala
@@ -1041,6 +1041,9 @@ class FidoMds3Spec extends AnyFunSpec with Matchers {
     val aaguidRetired =
       new AAGUID(ByteArray.fromHex("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"))
 
+    val aaguidNotRetired =
+      new AAGUID(ByteArray.fromHex("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"))
+
     val blob: MetadataBLOBPayload =
       JacksonCodecs.jsonWithDefaultEnums.readValue(
         s"""{
@@ -1070,6 +1073,27 @@ class FidoMds3Spec extends AnyFunSpec with Matchers {
               { "status": "RETIRED", "effectiveDate": "2022-02-01" }
             ],
             "timeOfLastStatusChange": "2022-02-15"
+          },
+          {
+            "aaguid": "${aaguidNotRetired.asGuidString()}",
+            "attestationCertificateKeyIdentifiers": [],
+            "metadataStatement": {
+              "aaguid": "${aaguidNotRetired.asGuidString()}",
+              "authenticatorVersion": 1,
+              "attestationRootCertificates": [],
+              "attestationTypes" : ["basic_full"],
+              "authenticationAlgorithms" : ["secp256r1_ecdsa_sha256_raw"],
+              "keyProtection" : ["software"],
+              "matcherProtection" : ["software"],
+              "protocolFamily" : "u2f",
+              "publicKeyAlgAndEncodings" : ["ecc_x962_raw"],
+              "schema" : 3,
+              "tcDisplay" : [],
+              "upv" : [{ "major" : 1, "minor" : 1 }],
+              "userVerificationDetails" : [[{ "userVerificationMethod" : "presence_internal" }]]
+            },
+           "statusReports": [],
+            "timeOfLastStatusChange": "2022-02-15"
           }
         ]
       }""".stripMargin,
@@ -1081,6 +1105,9 @@ class FidoMds3Spec extends AnyFunSpec with Matchers {
 
       mds
         .findEntries(aaguidRetired)
+        .asScala should not be empty
+      mds
+        .findEntries(aaguidNotRetired)
         .asScala should not be empty
     }
 
@@ -1094,6 +1121,9 @@ class FidoMds3Spec extends AnyFunSpec with Matchers {
       mds
         .findEntries(aaguidRetired)
         .asScala shouldBe empty
+      mds
+        .findEntries(aaguidNotRetired)
+        .asScala should not be empty
     }
 
   }


### PR DESCRIPTION
For example, the test now detects if the filter implementation is changed to `(entry) -> false` which was not detected before.