### PR TITLE
Add ATTACHMENT_HINT_SMART_CARD to FIDO metadata AttachmentHint

### DIFF
--- a/webauthn-server-attestation/src/main/java/com/yubico/fido/metadata/AttachmentHint.java
+++ b/webauthn-server-attestation/src/main/java/com/yubico/fido/metadata/AttachmentHint.java
@@ -129,7 +129,17 @@ public enum AttachmentHint {
    *     href="https://fidoalliance.org/specs/common-specs/fido-registry-v2.2-rd-20210525.html#authenticator-attachment-hints">FIDO
    *     Registry of Predefined Values §3.4 Authenticator Attachment Hints</a>
    */
-  ATTACHMENT_HINT_WIFI_DIRECT(0x0100, "wifi_direct");
+  ATTACHMENT_HINT_WIFI_DIRECT(0x0100, "wifi_direct"),
+
+  /**
+   * This flag MAY be set to indicate that the authenticator communicates with the FIDO User Device
+   * as a smart card.
+   *
+   * @see <a
+   *     href="https://fidoalliance.org/specs/common-specs/fido-registry-v2.2-rd-20210525.html#authenticator-attachment-hints">FIDO
+   *     Registry of Predefined Values §3.4 Authenticator Attachment Hints</a>
+   */
+  ATTACHMENT_HINT_SMART_CARD(0x0200, "smart-card");
 
   private final int value;
 


### PR DESCRIPTION
FIDO MDS metadata may include attachmentHint value smart-card; Jackson deserialization fails without this enum constant (Yubico#466).

Value 0x0200 (512) is the next bit after ATTACHMENT_HINT_WIFI_DIRECT.