### PR TITLE
Allow unknown MDS enum values and add missing fields

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -12,7 +12,7 @@ New features:
 
 * Added `AuthenticatorStatus.RETIRED` and `Filters.notRetired()`.
 * Added `AttachmentHint.ATTACHMENT_HINT_SMART_CARD`.
- ** Thanks to GitHub users mmoayyed and ErlendNukke for the contribution, see
+ ** Thanks to Misagh Moayyed and Erlend Nukke for the contribution, see
     https://github.com/Yubico/java-webauthn-server/pull/468 and
     https://github.com/Yubico/java-webauthn-server/pull/467
 * Added `UNKNOWN` constant to all enums in `com.yubico.fido.metadata`:

--- a/NEWS
+++ b/NEWS
@@ -25,6 +25,17 @@ New features:
  ** ProtocolFamily`
  ** PublicKeyRepresentationFormat`
  ** TransactionConfirmationDisplayType`
+* Added enum constant `CtapVersion.FIDO_2_3`.
+* Added missing fields to FIDO MDS data model:
+ ** `AuthenticatorGetInfo`: `attestationFormats`, `longTouchForReset`,
+    `uvCountSinceLastPinEntry`, `transportsForReset`, `pinComplexityPolicy`,
+    `pinComplexityPolicyURL`, `maxPINLength`, `authenticatorConfigCommands`
+ ** `BiometricAccuracyDescriptor`: `iAPARThreshold`
+ ** `MetadataStatement`: `friendlyNames`, `iconDark`, `providerLogoLight`,
+    `providerLogoDark`, `keyScope`, `multiDeviceCredentialSupport`,
+    `cxpConfigURL`
+ ** `StatusReport`: `certificationProfiles`, `sunsetDate`, `fipsRevision`,
+    `fipsPhysicalSecurityLevel`
 
 Fixes:
 

--- a/NEWS
+++ b/NEWS
@@ -11,6 +11,10 @@ Fixes:
 New features:
 
 * Added `AuthenticatorStatus.RETIRED` and `Filters.notRetired()`.
+* Added `AttachmentHint.ATTACHMENT_HINT_SMART_CARD`.
+ ** Thanks to GitHub users mmoayyed and ErlendNukke for the contribution, see
+    https://github.com/Yubico/java-webauthn-server/pull/468 and
+    https://github.com/Yubico/java-webauthn-server/pull/467
 
 Fixes:
 

--- a/NEWS
+++ b/NEWS
@@ -15,10 +15,22 @@ New features:
  ** Thanks to GitHub users mmoayyed and ErlendNukke for the contribution, see
     https://github.com/Yubico/java-webauthn-server/pull/468 and
     https://github.com/Yubico/java-webauthn-server/pull/467
+* Added `UNKNOWN` constant to all enums in `com.yubico.fido.metadata`:
+ ** `AttachmentHint`
+ ** `AuthenticationAlgorithm`
+ ** `AuthenticatorAttestationType`
+ ** `CtapCertificationId`
+ ** CtapPinUvAuthProtocolVersion`
+ ** CtapVersion`
+ ** ProtocolFamily`
+ ** PublicKeyRepresentationFormat`
+ ** TransactionConfirmationDisplayType`
 
 Fixes:
 
 * Added `@since` tags to `AuthenticatorStatus` and `FidoMetadataService` javadoc.
+* All `com.yubico.fido.metadata` enums now deserialize unknown values to
+  `UNKOWN` instead of crashing the parser.
 
 
 == Version 2.8.1 ==

--- a/NEWS
+++ b/NEWS
@@ -20,11 +20,11 @@ New features:
  ** `AuthenticationAlgorithm`
  ** `AuthenticatorAttestationType`
  ** `CtapCertificationId`
- ** CtapPinUvAuthProtocolVersion`
- ** CtapVersion`
- ** ProtocolFamily`
- ** PublicKeyRepresentationFormat`
- ** TransactionConfirmationDisplayType`
+ ** `CtapPinUvAuthProtocolVersion`
+ ** `CtapVersion`
+ ** `ProtocolFamily`
+ ** `PublicKeyRepresentationFormat`
+ ** `TransactionConfirmationDisplayType`
 * Added enum constant `CtapVersion.FIDO_2_3`.
 * Added missing fields to FIDO MDS data model:
  ** `AuthenticatorGetInfo`: `attestationFormats`, `longTouchForReset`,

--- a/webauthn-server-attestation/src/integrationTest/scala/com/yubico/fido/metadata/FidoMetadataDownloaderIntegrationTest.scala
+++ b/webauthn-server-attestation/src/integrationTest/scala/com/yubico/fido/metadata/FidoMetadataDownloaderIntegrationTest.scala
@@ -1,5 +1,6 @@
 package com.yubico.fido.metadata
 
+import com.yubico.fido.metadata.TestCaches.cachedDefaultSettingsDownloader
 import com.yubico.internal.util.CertificateParser
 import com.yubico.webauthn.data.ByteArray
 import org.junit.runner.RunWith
@@ -11,7 +12,6 @@ import org.scalatest.tags.Slow
 import org.scalatestplus.junit.JUnitRunner
 
 import scala.jdk.CollectionConverters.ListHasAsScala
-import scala.jdk.OptionConverters.RichOption
 import scala.util.Success
 import scala.util.Try
 
@@ -24,29 +24,10 @@ class FidoMetadataDownloaderIntegrationTest
     with BeforeAndAfter {
 
   describe("FidoMetadataDownloader with default settings") {
-    // Cache downloaded items to avoid cause unnecessary load on remote servers
-    var trustRootCache: Option[ByteArray] = None
-    var blobCache: Option[ByteArray] = None
-    val downloader =
-      FidoMetadataDownloader
-        .builder()
-        .expectLegalHeader(
-          "Retrieval and use of this BLOB indicates acceptance of the appropriate agreement located at https://fidoalliance.org/metadata/metadata-legal-terms/"
-        )
-        .useDefaultTrustRoot()
-        .useTrustRootCache(
-          () => trustRootCache.toJava,
-          trustRoot => { trustRootCache = Some(trustRoot) },
-        )
-        .useDefaultBlob()
-        .useBlobCache(
-          () => blobCache.toJava,
-          blob => { blobCache = Some(blob) },
-        )
-        .build()
+    val downloader = cachedDefaultSettingsDownloader.build()
 
     it("downloads and verifies the root cert and BLOB successfully.") {
-      val blob = Try(downloader.loadCachedBlob)
+      val blob = Try(TestCaches.cacheSynchronized(downloader.loadCachedBlob))
       blob shouldBe a[Success[_]]
       blob.get should not be null
     }
@@ -54,14 +35,22 @@ class FidoMetadataDownloaderIntegrationTest
     it(
       "does not encounter any CRLDistributionPoints entries in unknown format."
     ) {
-      val blob = Try(downloader.loadCachedBlob)
+      val blob = Try(TestCaches.cacheSynchronized(downloader.loadCachedBlob))
       blob shouldBe a[Success[_]]
       val trustRootCert =
-        CertificateParser.parseDer(trustRootCache.get.getBytes)
-      val certChain = downloader
-        .fetchHeaderCertChain(
-          trustRootCert,
-          FidoMetadataDownloader.parseBlob(blobCache.get).getBlob.getHeader,
+        CertificateParser.parseDer(
+          TestCaches.getTrustRootCache.get.get.getBytes
+        )
+      val certChain = TestCaches
+        .cacheSynchronized(
+          downloader
+            .fetchHeaderCertChain(
+              trustRootCert,
+              FidoMetadataDownloader
+                .parseBlob(TestCaches.getBlobCache.get.get)
+                .getBlob
+                .getHeader,
+            )
         )
         .asScala :+ trustRootCert
       for { cert <- certChain } {

--- a/webauthn-server-attestation/src/integrationTest/scala/com/yubico/fido/metadata/FidoMetadataDownloaderIntegrationTest.scala
+++ b/webauthn-server-attestation/src/integrationTest/scala/com/yubico/fido/metadata/FidoMetadataDownloaderIntegrationTest.scala
@@ -1,5 +1,6 @@
 package com.yubico.fido.metadata
 
+import com.fasterxml.jackson.databind.DeserializationFeature
 import com.yubico.fido.metadata.TestCaches.cachedDefaultSettingsDownloader
 import com.yubico.internal.util.CertificateParser
 import com.yubico.webauthn.data.ByteArray
@@ -46,7 +47,7 @@ class FidoMetadataDownloaderIntegrationTest
           downloader
             .fetchHeaderCertChain(
               trustRootCert,
-              FidoMetadataDownloader
+              downloader
                 .parseBlob(TestCaches.getBlobCache.get.get)
                 .getBlob
                 .getHeader,
@@ -62,6 +63,31 @@ class FidoMetadataDownloaderIntegrationTest
             .isAnyDistributionPointUnsupported should be(false)
         }
       }
+    }
+  }
+
+  describe("FidoMetadataDownloader with strict JSON deserialization settings") {
+    val downloader = cachedDefaultSettingsDownloader
+      .headerJsonMapper(() =>
+        com.yubico.internal.util.JacksonCodecs
+          .json()
+          .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, true)
+      )
+      .payloadJsonMapper(() =>
+        com.yubico.internal.util.JacksonCodecs
+          .json()
+          .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, true)
+          .configure(
+            DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_USING_DEFAULT_VALUE,
+            false,
+          )
+      )
+      .build()
+
+    it("downloads and parses the BLOB successfully.") {
+      val blob = Try(TestCaches.cacheSynchronized(downloader.loadCachedBlob))
+      blob shouldBe a[Success[_]]
+      blob.get should not be null
     }
   }
 

--- a/webauthn-server-attestation/src/integrationTest/scala/com/yubico/fido/metadata/FidoMetadataServiceIntegrationTest.scala
+++ b/webauthn-server-attestation/src/integrationTest/scala/com/yubico/fido/metadata/FidoMetadataServiceIntegrationTest.scala
@@ -5,6 +5,7 @@ import com.yubico.fido.metadata.AttachmentHint.ATTACHMENT_HINT_INTERNAL
 import com.yubico.fido.metadata.AttachmentHint.ATTACHMENT_HINT_NFC
 import com.yubico.fido.metadata.AttachmentHint.ATTACHMENT_HINT_WIRED
 import com.yubico.fido.metadata.AttachmentHint.ATTACHMENT_HINT_WIRELESS
+import com.yubico.fido.metadata.TestCaches.cachedDefaultSettingsDownloader
 import com.yubico.internal.util.CertificateParser
 import com.yubico.webauthn.FinishRegistrationOptions
 import com.yubico.webauthn.RelyingParty
@@ -22,7 +23,6 @@ import org.scalatestplus.junit.JUnitRunner
 
 import java.time.Clock
 import java.time.ZoneOffset
-import java.util.Optional
 import scala.jdk.CollectionConverters.SetHasAsJava
 import scala.jdk.CollectionConverters.SetHasAsScala
 import scala.jdk.OptionConverters.RichOptional
@@ -40,21 +40,12 @@ class FidoMetadataServiceIntegrationTest
   describe("FidoMetadataService") {
 
     describe("downloaded with default settings") {
-      val downloader = FidoMetadataDownloader
-        .builder()
-        .expectLegalHeader(
-          "Retrieval and use of this BLOB indicates acceptance of the appropriate agreement located at https://fidoalliance.org/metadata/metadata-legal-terms/"
-        )
-        .useDefaultTrustRoot()
-        .useTrustRootCache(() => Optional.empty(), _ => {})
-        .useDefaultBlob()
-        .useBlobCache(() => Optional.empty(), _ => {})
-        .build()
+      val downloader = cachedDefaultSettingsDownloader.build()
       val fidoMds =
         Try(
           FidoMetadataService
             .builder()
-            .useBlob(downloader.loadCachedBlob())
+            .useBlob(TestCaches.cacheSynchronized(downloader.loadCachedBlob()))
             .build()
         )
 

--- a/webauthn-server-attestation/src/integrationTest/scala/com/yubico/fido/metadata/TestCaches.scala
+++ b/webauthn-server-attestation/src/integrationTest/scala/com/yubico/fido/metadata/TestCaches.scala
@@ -1,0 +1,42 @@
+package com.yubico.fido.metadata
+
+import com.yubico.webauthn.data.ByteArray
+
+import java.util.Optional
+import java.util.function.Consumer
+import java.util.function.Supplier
+import scala.jdk.OptionConverters.RichOption
+
+object TestCaches {
+
+  // Cache downloaded items to avoid unnecessary load on remote servers, and so tests don't have to wait for rate limiting
+
+  private var trustRootCache: Option[ByteArray] = None
+  val getTrustRootCache: Supplier[Optional[ByteArray]] = () =>
+    trustRootCache.toJava
+  val setTrustRootCache: Consumer[ByteArray] = trustRoot => {
+    trustRootCache = Some(trustRoot)
+  }
+
+  private var blobCache: Option[ByteArray] = None
+  val getBlobCache: Supplier[Optional[ByteArray]] = () => blobCache.toJava
+  val setBlobCache: Consumer[ByteArray] = blob => { blobCache = Some(blob) }
+
+  def cachedDefaultSettingsDownloader
+      : FidoMetadataDownloader.FidoMetadataDownloaderBuilder =
+    FidoMetadataDownloader
+      .builder()
+      .expectLegalHeader(
+        "Retrieval and use of this BLOB indicates acceptance of the appropriate agreement located at https://fidoalliance.org/metadata/metadata-legal-terms/"
+      )
+      .useDefaultTrustRoot()
+      .useTrustRootCache(getTrustRootCache, setTrustRootCache)
+      .useDefaultBlob()
+      .useBlobCache(getBlobCache, setBlobCache)
+
+  /** Evaluate <code>expr</code> with an exclusive lock on the test cache. */
+  def cacheSynchronized[A](expr: => A): A = {
+    this.synchronized(expr)
+  }
+
+}

--- a/webauthn-server-attestation/src/main/java/com/yubico/fido/metadata/AttachmentHint.java
+++ b/webauthn-server-attestation/src/main/java/com/yubico/fido/metadata/AttachmentHint.java
@@ -137,6 +137,7 @@ public enum AttachmentHint {
    * reporting characteristics through discovery, if this flag is set, the {@link
    * #ATTACHMENT_HINT_WIRED} flag SHOULD also be set.
    *
+   * @since 2.9.0
    * @see <a
    *     href="https://fidoalliance.org/specs/common-specs/fido-registry-v2.3-rd-20260105.html#authenticator-attachment-hints">FIDO
    *     Registry of Predefined Values §3.4 Authenticator Attachment Hints</a>

--- a/webauthn-server-attestation/src/main/java/com/yubico/fido/metadata/AttachmentHint.java
+++ b/webauthn-server-attestation/src/main/java/com/yubico/fido/metadata/AttachmentHint.java
@@ -129,7 +129,17 @@ public enum AttachmentHint {
    *     href="https://fidoalliance.org/specs/common-specs/fido-registry-v2.2-rd-20210525.html#authenticator-attachment-hints">FIDO
    *     Registry of Predefined Values §3.4 Authenticator Attachment Hints</a>
    */
-  ATTACHMENT_HINT_WIFI_DIRECT(0x0100, "wifi_direct");
+  ATTACHMENT_HINT_WIFI_DIRECT(0x0100, "wifi_direct"),
+
+  /**
+   * This flag MAY be set to indicate that the authenticator communicates with the FIDO User Device
+   * as a smart card.
+   *
+   * @see <a
+   *     href="https://fidoalliance.org/specs/common-specs/fido-registry-v2.2-rd-20210525.html#authenticator-attachment-hints">FIDO
+   *     Registry of Predefined Values §3.4 Authenticator Attachment Hints</a>
+   */
+  ATTACHMENT_HINT_SMART_CARD(0x0200, "smart-card");
 
   private final int value;
 

--- a/webauthn-server-attestation/src/main/java/com/yubico/fido/metadata/AttachmentHint.java
+++ b/webauthn-server-attestation/src/main/java/com/yubico/fido/metadata/AttachmentHint.java
@@ -132,10 +132,11 @@ public enum AttachmentHint {
   ATTACHMENT_HINT_WIFI_DIRECT(0x0100, "wifi_direct"),
 
   /**
-   * This flag MAY be set to indicate that an external authenticator is able to communicate
-   * by ISO7816 messages with the FIDO User Device. As part of authenticator metadata,
-   * or when reporting characteristics through discovery, if this flag is set, the {@link #ATTACHMENT_HINT_WIRED}
-   * flag SHOULD also be set.
+   * This flag MAY be set to indicate that an external authenticator is able to communicate by
+   * ISO7816 messages with the FIDO User Device. As part of authenticator metadata, or when
+   * reporting characteristics through discovery, if this flag is set, the {@link
+   * #ATTACHMENT_HINT_WIRED} flag SHOULD also be set.
+   *
    * @see <a
    *     href="https://fidoalliance.org/specs/common-specs/fido-registry-v2.3-rd-20260105.html#authenticator-attachment-hints">FIDO
    *     Registry of Predefined Values §3.4 Authenticator Attachment Hints</a>

--- a/webauthn-server-attestation/src/main/java/com/yubico/fido/metadata/AttachmentHint.java
+++ b/webauthn-server-attestation/src/main/java/com/yubico/fido/metadata/AttachmentHint.java
@@ -129,7 +129,18 @@ public enum AttachmentHint {
    *     href="https://fidoalliance.org/specs/common-specs/fido-registry-v2.2-rd-20210525.html#authenticator-attachment-hints">FIDO
    *     Registry of Predefined Values §3.4 Authenticator Attachment Hints</a>
    */
-  ATTACHMENT_HINT_WIFI_DIRECT(0x0100, "wifi_direct");
+  ATTACHMENT_HINT_WIFI_DIRECT(0x0100, "wifi_direct"),
+
+  /**
+   * This flag MAY be set to indicate that an external authenticator is able to communicate
+   * by ISO7816 messages with the FIDO User Device. As part of authenticator metadata,
+   * or when reporting characteristics through discovery, if this flag is set, the {@link #ATTACHMENT_HINT_WIRED}
+   * flag SHOULD also be set.
+   * @see <a
+   *     href="https://fidoalliance.org/specs/common-specs/fido-registry-v2.3-rd-20260105.html#authenticator-attachment-hints">FIDO
+   *     Registry of Predefined Values §3.4 Authenticator Attachment Hints</a>
+   */
+  ATTACHMENT_HINT_SMART_CARD(0x0200, "smart-card");
 
   private final int value;
 

--- a/webauthn-server-attestation/src/main/java/com/yubico/fido/metadata/AttachmentHint.java
+++ b/webauthn-server-attestation/src/main/java/com/yubico/fido/metadata/AttachmentHint.java
@@ -1,5 +1,6 @@
 package com.yubico.fido.metadata;
 
+import com.fasterxml.jackson.annotation.JsonEnumDefaultValue;
 import com.fasterxml.jackson.annotation.JsonValue;
 
 /**
@@ -21,6 +22,14 @@ import com.fasterxml.jackson.annotation.JsonValue;
  *     Registry of Predefined Values §3.4 Authenticator Attachment Hints</a>
  */
 public enum AttachmentHint {
+
+  /**
+   * (NOT DEFINED IN SPEC) Placeholder for any unknown {@link AttachmentHint} value.
+   *
+   * @since 2.9.0
+   */
+  @JsonEnumDefaultValue
+  UNKNOWN(0, "UNKNOWN"),
 
   /**
    * This flag MAY be set to indicate that the authenticator is permanently attached to the FIDO

--- a/webauthn-server-attestation/src/main/java/com/yubico/fido/metadata/AuthenticationAlgorithm.java
+++ b/webauthn-server-attestation/src/main/java/com/yubico/fido/metadata/AuthenticationAlgorithm.java
@@ -1,5 +1,6 @@
 package com.yubico.fido.metadata;
 
+import com.fasterxml.jackson.annotation.JsonEnumDefaultValue;
 import com.fasterxml.jackson.annotation.JsonValue;
 
 /**
@@ -14,6 +15,14 @@ import com.fasterxml.jackson.annotation.JsonValue;
  *     Registry of Predefined Values §3.6.1 Authentication Algorithms</a>
  */
 public enum AuthenticationAlgorithm {
+
+  /**
+   * (NOT DEFINED IN SPEC) Placeholder for any unknown {@link AuthenticationAlgorithm} value.
+   *
+   * @since 2.9.0
+   */
+  @JsonEnumDefaultValue
+  UNKNOWN(0, "UNKNOWN"),
 
   /**
    * @see <a

--- a/webauthn-server-attestation/src/main/java/com/yubico/fido/metadata/AuthenticatorAttestationType.java
+++ b/webauthn-server-attestation/src/main/java/com/yubico/fido/metadata/AuthenticatorAttestationType.java
@@ -1,5 +1,6 @@
 package com.yubico.fido.metadata;
 
+import com.fasterxml.jackson.annotation.JsonEnumDefaultValue;
 import com.fasterxml.jackson.annotation.JsonValue;
 
 /**
@@ -14,6 +15,14 @@ import com.fasterxml.jackson.annotation.JsonValue;
  *     Registry of Predefined Values §3.7 Authenticator Attestation Types</a>
  */
 public enum AuthenticatorAttestationType {
+
+  /**
+   * (NOT DEFINED IN SPEC) Placeholder for any unknown {@link AuthenticatorAttestationType} value.
+   *
+   * @since 2.9.0
+   */
+  @JsonEnumDefaultValue
+  UNKNOWN(0, "UNKNOWN"),
 
   /**
    * Indicates full basic attestation, based on an attestation private key shared among a class of

--- a/webauthn-server-attestation/src/main/java/com/yubico/fido/metadata/AuthenticatorGetInfo.java
+++ b/webauthn-server-attestation/src/main/java/com/yubico/fido/metadata/AuthenticatorGetInfo.java
@@ -45,9 +45,11 @@ import lombok.extern.jackson.Jacksonized;
 @Builder(toBuilder = true)
 @Jacksonized
 @JsonIgnoreProperties({
-  "maxAuthenticatorConfigLength",
-  "defaultCredProtect"
-}) // Present in example but not defined
+  "maxAuthenticatorConfigLength", // Present in example but not defined
+  "defaultCredProtect", // Present in example but not defined
+  "encIdentifier", // Nonsensical in MDS context
+  "encCredStoreState" // Nonsensical in MDS context
+})
 public class AuthenticatorGetInfo {
 
   /**
@@ -177,6 +179,139 @@ public class AuthenticatorGetInfo {
   Map<CtapCertificationId, Integer> certifications;
   Integer remainingDiscoverableCredentials;
   Set<Integer> vendorPrototypeConfigCommands;
+
+  /**
+   * @since 2.9.0
+   * @see <a
+   *     href="https://fidoalliance.org/specs/fido-v2.3-ps-20260226/fido-client-to-authenticator-protocol-v2.3-ps-20260226.html#authenticatorGetInfo">Client
+   *     to Authenticator Protocol (CTAP) §6.4. authenticatorGetInfo (0x04)</a>
+   */
+  List<String> attestationFormats;
+
+  /**
+   * <code>true</code> if the <code>longTouchForReset</code> member is set to <code>true</code> or
+   * <code>false</code> in the metadata statement. <code>false</code> if the <code>longTouchForReset
+   * </code> member is absent in the metadata statement.
+   *
+   * @since 2.9.0
+   * @see <a
+   *     href="https://fidoalliance.org/specs/fido-v2.3-ps-20260226/fido-client-to-authenticator-protocol-v2.3-ps-20260226.html#authenticatorGetInfo">Client
+   *     to Authenticator Protocol (CTAP) §6.4. authenticatorGetInfo (0x04)</a>
+   */
+  boolean longTouchForReset;
+
+  /**
+   * @since 2.9.0
+   * @see <a
+   *     href="https://fidoalliance.org/specs/fido-v2.3-ps-20260226/fido-client-to-authenticator-protocol-v2.3-ps-20260226.html#authenticatorGetInfo">Client
+   *     to Authenticator Protocol (CTAP) §6.4. authenticatorGetInfo (0x04)</a>
+   */
+  Integer uvCountSinceLastPinEntry;
+
+  /**
+   * @since 2.9.0
+   * @see <a
+   *     href="https://fidoalliance.org/specs/fido-v2.3-ps-20260226/fido-client-to-authenticator-protocol-v2.3-ps-20260226.html#authenticatorGetInfo">Client
+   *     to Authenticator Protocol (CTAP) §6.4. authenticatorGetInfo (0x04)</a>
+   */
+  Set<String> transportsForReset;
+
+  /**
+   * <code>true</code> if the <code>pinComplexityPolicy</code> member is set to <code>true</code> or
+   * <code>false</code> in the metadata statement. <code>false</code> if the <code>
+   * pinComplexityPolicy</code> member is absent in the metadata statement.
+   *
+   * @since 2.9.0
+   * @see <a
+   *     href="https://fidoalliance.org/specs/fido-v2.3-ps-20260226/fido-client-to-authenticator-protocol-v2.3-ps-20260226.html#authenticatorGetInfo">Client
+   *     to Authenticator Protocol (CTAP) §6.4. authenticatorGetInfo (0x04)</a>
+   */
+  boolean pinComplexityPolicy;
+
+  /**
+   * @since 2.9.0
+   * @see <a
+   *     href="https://fidoalliance.org/specs/fido-v2.3-ps-20260226/fido-client-to-authenticator-protocol-v2.3-ps-20260226.html#authenticatorGetInfo">Client
+   *     to Authenticator Protocol (CTAP) §6.4. authenticatorGetInfo (0x04)</a>
+   */
+  String pinComplexityPolicyURL;
+
+  /**
+   * @since 2.9.0
+   * @see <a
+   *     href="https://fidoalliance.org/specs/fido-v2.3-ps-20260226/fido-client-to-authenticator-protocol-v2.3-ps-20260226.html#authenticatorGetInfo">Client
+   *     to Authenticator Protocol (CTAP) §6.4. authenticatorGetInfo (0x04)</a>
+   */
+  Integer maxPINLength;
+
+  /**
+   * @since 2.9.0
+   * @see <a
+   *     href="https://fidoalliance.org/specs/fido-v2.3-ps-20260226/fido-client-to-authenticator-protocol-v2.3-ps-20260226.html#authenticatorGetInfo">Client
+   *     to Authenticator Protocol (CTAP) §6.4. authenticatorGetInfo (0x04)</a>
+   */
+  Set<Integer> authenticatorConfigCommands;
+
+  AuthenticatorGetInfo(
+      @NonNull Set<CtapVersion> versions,
+      Set<String> extensions,
+      AAGUID aaguid,
+      SupportedCtapOptions options,
+      Integer maxMsgSize,
+      Set<CtapPinUvAuthProtocolVersion> pinUvAuthProtocols,
+      Integer maxCredentialCountInList,
+      Integer maxCredentialIdLength,
+      Set<AuthenticatorTransport> transports,
+      List<PublicKeyCredentialParameters> algorithms,
+      Integer maxSerializedLargeBlobArray,
+      Boolean forcePINChange,
+      Integer minPINLength,
+      Integer firmwareVersion,
+      Integer maxCredBlobLength,
+      Integer maxRPIDsForSetMinPINLength,
+      Integer preferredPlatformUvAttempts,
+      Set<UserVerificationMethod> uvModality,
+      Map<CtapCertificationId, Integer> certifications,
+      Integer remainingDiscoverableCredentials,
+      Set<Integer> vendorPrototypeConfigCommands,
+      List<String> attestationFormats,
+      Boolean longTouchForReset,
+      Integer uvCountSinceLastPinEntry,
+      Set<String> transportsForReset,
+      Boolean pinComplexityPolicy,
+      String pinComplexityPolicyURL,
+      Integer maxPINLength,
+      Set<Integer> authenticatorConfigCommands) {
+    this.versions = versions;
+    this.extensions = extensions;
+    this.aaguid = aaguid;
+    this.options = options;
+    this.maxMsgSize = maxMsgSize;
+    this.pinUvAuthProtocols = pinUvAuthProtocols;
+    this.maxCredentialCountInList = maxCredentialCountInList;
+    this.maxCredentialIdLength = maxCredentialIdLength;
+    this.transports = transports;
+    this.algorithms = algorithms;
+    this.maxSerializedLargeBlobArray = maxSerializedLargeBlobArray;
+    this.forcePINChange = forcePINChange;
+    this.minPINLength = minPINLength;
+    this.firmwareVersion = firmwareVersion;
+    this.maxCredBlobLength = maxCredBlobLength;
+    this.maxRPIDsForSetMinPINLength = maxRPIDsForSetMinPINLength;
+    this.preferredPlatformUvAttempts = preferredPlatformUvAttempts;
+    this.uvModality = uvModality;
+    this.certifications = certifications;
+    this.remainingDiscoverableCredentials = remainingDiscoverableCredentials;
+    this.vendorPrototypeConfigCommands = vendorPrototypeConfigCommands;
+    this.attestationFormats = attestationFormats;
+    this.longTouchForReset = longTouchForReset != null;
+    this.uvCountSinceLastPinEntry = uvCountSinceLastPinEntry;
+    this.transportsForReset = transportsForReset;
+    this.pinComplexityPolicy = pinComplexityPolicy != null;
+    this.pinComplexityPolicyURL = pinComplexityPolicyURL;
+    this.maxPINLength = maxPINLength;
+    this.authenticatorConfigCommands = authenticatorConfigCommands;
+  }
 
   /**
    * @see <a
@@ -356,6 +491,66 @@ public class AuthenticatorGetInfo {
    */
   public Optional<Set<Integer>> getVendorPrototypeConfigCommands() {
     return Optional.ofNullable(vendorPrototypeConfigCommands);
+  }
+
+  /**
+   * @since 2.9.0
+   * @see <a
+   *     href="https://fidoalliance.org/specs/fido-v2.3-ps-20260226/fido-client-to-authenticator-protocol-v2.3-ps-20260226.html#authenticatorGetInfo">Client
+   *     to Authenticator Protocol (CTAP) §6.4. authenticatorGetInfo (0x04)</a>
+   */
+  public Optional<List<String>> getAttestationFormats() {
+    return Optional.ofNullable(attestationFormats);
+  }
+
+  /**
+   * @since 2.9.0
+   * @see <a
+   *     href="https://fidoalliance.org/specs/fido-v2.3-ps-20260226/fido-client-to-authenticator-protocol-v2.3-ps-20260226.html#authenticatorGetInfo">Client
+   *     to Authenticator Protocol (CTAP) §6.4. authenticatorGetInfo (0x04)</a>
+   */
+  public Optional<Integer> getUvCountSinceLastPinEntry() {
+    return Optional.ofNullable(uvCountSinceLastPinEntry);
+  }
+
+  /**
+   * @since 2.9.0
+   * @see <a
+   *     href="https://fidoalliance.org/specs/fido-v2.3-ps-20260226/fido-client-to-authenticator-protocol-v2.3-ps-20260226.html#authenticatorGetInfo">Client
+   *     to Authenticator Protocol (CTAP) §6.4. authenticatorGetInfo (0x04)</a>
+   */
+  public Optional<Set<String>> getTransportsForReset() {
+    return Optional.ofNullable(transportsForReset);
+  }
+
+  /**
+   * @since 2.9.0
+   * @see <a
+   *     href="https://fidoalliance.org/specs/fido-v2.3-ps-20260226/fido-client-to-authenticator-protocol-v2.3-ps-20260226.html#authenticatorGetInfo">Client
+   *     to Authenticator Protocol (CTAP) §6.4. authenticatorGetInfo (0x04)</a>
+   */
+  public Optional<String> getPinComplexityPolicyURL() {
+    return Optional.ofNullable(pinComplexityPolicyURL);
+  }
+
+  /**
+   * @since 2.9.0
+   * @see <a
+   *     href="https://fidoalliance.org/specs/fido-v2.3-ps-20260226/fido-client-to-authenticator-protocol-v2.3-ps-20260226.html#authenticatorGetInfo">Client
+   *     to Authenticator Protocol (CTAP) §6.4. authenticatorGetInfo (0x04)</a>
+   */
+  public Optional<Integer> getMaxPINLength() {
+    return Optional.ofNullable(maxPINLength);
+  }
+
+  /**
+   * @since 2.9.0
+   * @see <a
+   *     href="https://fidoalliance.org/specs/fido-v2.3-ps-20260226/fido-client-to-authenticator-protocol-v2.3-ps-20260226.html#authenticatorGetInfo">Client
+   *     to Authenticator Protocol (CTAP) §6.4. authenticatorGetInfo (0x04)</a>
+   */
+  public Optional<Set<Integer>> getAuthenticatorConfigCommands() {
+    return Optional.ofNullable(authenticatorConfigCommands);
   }
 
   private static class SetFromIntJsonDeserializer

--- a/webauthn-server-attestation/src/main/java/com/yubico/fido/metadata/BiometricAccuracyDescriptor.java
+++ b/webauthn-server-attestation/src/main/java/com/yubico/fido/metadata/BiometricAccuracyDescriptor.java
@@ -1,5 +1,6 @@
 package com.yubico.fido.metadata;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.Optional;
 import lombok.Builder;
 import lombok.Value;
@@ -24,6 +25,7 @@ public class BiometricAccuracyDescriptor {
 
   Double selfAttestedFRR;
   Double selfAttestedFAR;
+  Double iAPARThreshold;
   Integer maxTemplates;
   Integer maxRetries;
   Integer blockSlowdown;
@@ -44,6 +46,17 @@ public class BiometricAccuracyDescriptor {
    */
   public Optional<Double> getSelfAttestedFAR() {
     return Optional.ofNullable(selfAttestedFAR);
+  }
+
+  /**
+   * @since 2.9.0
+   * @see <a
+   *     href="https://fidoalliance.org/specs/mds/fido-metadata-statement-v3.1-ps-20250521.html#sctn-type-bad">FIDO
+   *     Metadata Statement §3.3. BiometricAccuracyDescriptor dictionary</a>
+   */
+  @JsonProperty("iAPARThreshold")
+  public Optional<Double> getIAPARThreshold() {
+    return Optional.ofNullable(iAPARThreshold);
   }
 
   /**

--- a/webauthn-server-attestation/src/main/java/com/yubico/fido/metadata/CtapCertificationId.java
+++ b/webauthn-server-attestation/src/main/java/com/yubico/fido/metadata/CtapCertificationId.java
@@ -1,5 +1,6 @@
 package com.yubico.fido.metadata;
 
+import com.fasterxml.jackson.annotation.JsonEnumDefaultValue;
 import com.fasterxml.jackson.annotation.JsonValue;
 
 /**
@@ -14,6 +15,14 @@ import com.fasterxml.jackson.annotation.JsonValue;
  *     to Authenticator Protocol (CTAP) §7.3. Authenticator Certifications</a>
  */
 public enum CtapCertificationId {
+
+  /**
+   * (NOT DEFINED IN SPEC) Placeholder for any unknown {@link CtapCertificationId} value.
+   *
+   * @since 2.9.0
+   */
+  @JsonEnumDefaultValue
+  UNKNOWN("UNKNOWN"),
 
   /**
    * @see <a

--- a/webauthn-server-attestation/src/main/java/com/yubico/fido/metadata/CtapPinUvAuthProtocolVersion.java
+++ b/webauthn-server-attestation/src/main/java/com/yubico/fido/metadata/CtapPinUvAuthProtocolVersion.java
@@ -1,5 +1,6 @@
 package com.yubico.fido.metadata;
 
+import com.fasterxml.jackson.annotation.JsonEnumDefaultValue;
 import com.fasterxml.jackson.annotation.JsonValue;
 
 /**
@@ -10,6 +11,14 @@ import com.fasterxml.jackson.annotation.JsonValue;
  *     to Authenticator Protocol (CTAP) §6.5. authenticatorClientPIN (0x06)</a>
  */
 public enum CtapPinUvAuthProtocolVersion {
+
+  /**
+   * (NOT DEFINED IN SPEC) Placeholder for any unknown {@link CtapPinUvAuthProtocolVersion} value.
+   *
+   * @since 2.9.0
+   */
+  @JsonEnumDefaultValue
+  UNKNOWN(0),
 
   /**
    * Represents PIN/UV Auth Protocol One.

--- a/webauthn-server-attestation/src/main/java/com/yubico/fido/metadata/CtapVersion.java
+++ b/webauthn-server-attestation/src/main/java/com/yubico/fido/metadata/CtapVersion.java
@@ -1,5 +1,6 @@
 package com.yubico.fido.metadata;
 
+import com.fasterxml.jackson.annotation.JsonAlias;
 import com.fasterxml.jackson.annotation.JsonEnumDefaultValue;
 
 /**
@@ -17,6 +18,7 @@ public enum CtapVersion {
    * @since 2.9.0
    */
   @JsonEnumDefaultValue
+  @JsonAlias("FIDO_2_2") // Forbidden by CTAP 2.3 spec
   UNKNOWN,
 
   /**
@@ -45,5 +47,13 @@ public enum CtapVersion {
    *     href="https://fidoalliance.org/specs/fido-v2.1-ps-20210615/fido-client-to-authenticator-protocol-v2.1-ps-20210615.html#authenticatorGetInfo">Client
    *     to Authenticator Protocol (CTAP) §6.4. authenticatorGetInfo (0x04)</a>
    */
-  FIDO_2_1;
+  FIDO_2_1,
+
+  /**
+   * @since 2.9.0
+   * @see <a
+   *     href="https://fidoalliance.org/specs/fido-v2.3-ps-20260226/fido-client-to-authenticator-protocol-v2.3-ps-20260226.html#authenticatorGetInfo">Client
+   *     to Authenticator Protocol (CTAP) §6.4. authenticatorGetInfo (0x04)</a>
+   */
+  FIDO_2_3;
 }

--- a/webauthn-server-attestation/src/main/java/com/yubico/fido/metadata/CtapVersion.java
+++ b/webauthn-server-attestation/src/main/java/com/yubico/fido/metadata/CtapVersion.java
@@ -1,5 +1,7 @@
 package com.yubico.fido.metadata;
 
+import com.fasterxml.jackson.annotation.JsonEnumDefaultValue;
+
 /**
  * Enumeration of CTAP versions.
  *
@@ -8,6 +10,14 @@ package com.yubico.fido.metadata;
  *     to Authenticator Protocol (CTAP) §6.4. authenticatorGetInfo (0x04)</a>
  */
 public enum CtapVersion {
+
+  /**
+   * (NOT DEFINED IN SPEC) Placeholder for any unknown {@link CtapVersion} value.
+   *
+   * @since 2.9.0
+   */
+  @JsonEnumDefaultValue
+  UNKNOWN,
 
   /**
    * @see <a

--- a/webauthn-server-attestation/src/main/java/com/yubico/fido/metadata/FidoMetadataDownloader.java
+++ b/webauthn-server-attestation/src/main/java/com/yubico/fido/metadata/FidoMetadataDownloader.java
@@ -123,6 +123,12 @@ public final class FidoMetadataDownloader {
   private final KeyStore httpsTrustStore;
   private final boolean verifyDownloadsOnly;
 
+  /** For overriding JSON mapper settings in tests. */
+  private final Supplier<ObjectMapper> makeHeaderJsonMapper;
+
+  /** For overriding JSON mapper settings in tests. */
+  private final Supplier<ObjectMapper> makePayloadJsonMapper;
+
   /**
    * Begin configuring a {@link FidoMetadataDownloader} instance. See the {@link
    * FidoMetadataDownloaderBuilder.Step1 Step1} type.
@@ -153,6 +159,11 @@ public final class FidoMetadataDownloader {
     private KeyStore httpsTrustStore = null;
     private boolean verifyDownloadsOnly = false;
 
+    private Supplier<ObjectMapper> makeHeaderJsonMapper =
+        FidoMetadataDownloader::defaultHeaderJsonMapper;
+    private Supplier<ObjectMapper> makePayloadJsonMapper =
+        FidoMetadataDownloader::defaultPayloadJsonMapper;
+
     public FidoMetadataDownloader build() {
       return new FidoMetadataDownloader(
           expectedLegalHeaders,
@@ -170,7 +181,9 @@ public final class FidoMetadataDownloader {
           certStore,
           clock,
           httpsTrustStore,
-          verifyDownloadsOnly);
+          verifyDownloadsOnly,
+          makeHeaderJsonMapper,
+          makePayloadJsonMapper);
     }
 
     /**
@@ -634,6 +647,20 @@ public final class FidoMetadataDownloader {
      */
     public FidoMetadataDownloaderBuilder verifyDownloadsOnly(final boolean verifyDownloadsOnly) {
       this.verifyDownloadsOnly = verifyDownloadsOnly;
+      return this;
+    }
+
+    /** For internal testing use only. */
+    FidoMetadataDownloaderBuilder headerJsonMapper(
+        final Supplier<ObjectMapper> makeHeaderJsonMapper) {
+      this.makeHeaderJsonMapper = makeHeaderJsonMapper;
+      return this;
+    }
+
+    /** For internal testing use only. */
+    FidoMetadataDownloaderBuilder payloadJsonMapper(
+        final Supplier<ObjectMapper> makePayloadJsonMapper) {
+      this.makePayloadJsonMapper = makePayloadJsonMapper;
       return this;
     }
   }
@@ -1145,23 +1172,32 @@ public final class FidoMetadataDownloader {
     return parseResult.blob;
   }
 
-  static ParseResult parseBlob(ByteArray jwt) throws IOException, Base64UrlException {
+  ParseResult parseBlob(ByteArray jwt) throws IOException, Base64UrlException {
     Scanner s = new Scanner(new ByteArrayInputStream(jwt.getBytes())).useDelimiter("\\.");
     final ByteArray jwtHeader = ByteArray.fromBase64Url(s.next());
     final ByteArray jwtPayload = ByteArray.fromBase64Url(s.next());
     final ByteArray jwtSignature = ByteArray.fromBase64Url(s.next());
 
     final ObjectMapper headerJsonMapper =
-        JacksonCodecs.json().setBase64Variant(Base64Variants.MIME_NO_LINEFEEDS);
+        makeHeaderJsonMapper.get().setBase64Variant(Base64Variants.MIME_NO_LINEFEEDS);
 
     return new ParseResult(
         new MetadataBLOB(
             headerJsonMapper.readValue(jwtHeader.getBytes(), MetadataBLOBHeader.class),
-            JacksonCodecs.jsonWithDefaultEnums()
+            makePayloadJsonMapper
+                .get()
                 .readValue(jwtPayload.getBytes(), MetadataBLOBPayload.class)),
         jwtHeader,
         jwtPayload,
         jwtSignature);
+  }
+
+  static ObjectMapper defaultHeaderJsonMapper() {
+    return JacksonCodecs.json();
+  }
+
+  static ObjectMapper defaultPayloadJsonMapper() {
+    return JacksonCodecs.jsonWithDefaultEnums();
   }
 
   private static ByteArray readAll(InputStream is) throws IOException {

--- a/webauthn-server-attestation/src/main/java/com/yubico/fido/metadata/MetadataStatement.java
+++ b/webauthn-server-attestation/src/main/java/com/yubico/fido/metadata/MetadataStatement.java
@@ -7,6 +7,7 @@ import com.yubico.webauthn.extension.uvm.KeyProtectionType;
 import com.yubico.webauthn.extension.uvm.MatcherProtectionType;
 import java.security.cert.X509Certificate;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import lombok.Builder;
@@ -59,6 +60,14 @@ public class MetadataStatement {
    *     Metadata Statement</a>
    */
   Set<String> attestationCertificateKeyIdentifiers;
+
+  /**
+   * @since 2.9.0
+   * @see <a
+   *     href="https://fidoalliance.org/specs/mds/fido-metadata-statement-v3.1-ps-20250521.html#dom-metadatastatement-friendlynames">FIDO
+   *     Metadata Statement</a>
+   */
+  Map<String, String> friendlyNames;
 
   /**
    * @see <a
@@ -211,11 +220,51 @@ public class MetadataStatement {
   String icon;
 
   /**
+   * @since 2.9.0
+   * @see <a
+   *     href="https://fidoalliance.org/specs/mds/fido-metadata-statement-v3.1-ps-20250521.html#dom-metadatastatement-icondark">FIDO
+   *     Metadata Statement</a>
+   */
+  String iconDark;
+
+  /**
+   * @since 2.9.0
+   * @see <a
+   *     href="https://fidoalliance.org/specs/mds/fido-metadata-statement-v3.1-ps-20250521.html#dom-metadatastatement-providerlogolight">FIDO
+   *     Metadata Statement</a>
+   */
+  String providerLogoLight;
+
+  /**
+   * @since 2.9.0
+   * @see <a
+   *     href="https://fidoalliance.org/specs/mds/fido-metadata-statement-v3.1-ps-20250521.html#dom-metadatastatement-providerlogodark">FIDO
+   *     Metadata Statement</a>
+   */
+  String providerLogoDark;
+
+  /**
    * @see <a
    *     href="https://fidoalliance.org/specs/mds/fido-metadata-statement-v3.0-ps-20210518.html#metadata-statement-format">FIDO
    *     Metadata Statement</a>
    */
   Set<ExtensionDescriptor> supportedExtensions;
+
+  /**
+   * @since 2.9.0
+   * @see <a
+   *     href="https://fidoalliance.org/specs/mds/fido-metadata-statement-v3.1-ps-20250521.html#dom-metadatastatement-keyscope">FIDO
+   *     Metadata Statement</a>
+   */
+  String keyScope;
+
+  /**
+   * @since 2.9.0
+   * @see <a
+   *     href="https://fidoalliance.org/specs/mds/fido-metadata-statement-v3.1-ps-20250521.html#dom-metadatastatement-multidevicecredentialsupport">FIDO
+   *     Metadata Statement</a>
+   */
+  String multiDeviceCredentialSupport;
 
   /**
    * @see <a
@@ -224,11 +273,20 @@ public class MetadataStatement {
    */
   AuthenticatorGetInfo authenticatorGetInfo;
 
+  /**
+   * @since 2.9.0
+   * @see <a
+   *     href="https://fidoalliance.org/specs/mds/fido-metadata-statement-v3.1-ps-20250521.html#dom-metadatastatement-cxpconfigurl">FIDO
+   *     Metadata Statement</a>
+   */
+  String cxpConfigURL;
+
   public MetadataStatement(
       String legalHeader,
       AAID aaid,
       AAGUID aaguid,
       Set<String> attestationCertificateKeyIdentifiers,
+      Map<String, String> friendlyNames,
       String description,
       AlternativeDescriptions alternativeDescriptions,
       long authenticatorVersion,
@@ -250,13 +308,20 @@ public class MetadataStatement {
       List<DisplayPNGCharacteristicsDescriptor> tcDisplayPNGCharacteristics,
       @NonNull Set<X509Certificate> attestationRootCertificates,
       String icon,
+      String iconDark,
+      String providerLogoLight,
+      String providerLogoDark,
       Set<ExtensionDescriptor> supportedExtensions,
-      AuthenticatorGetInfo authenticatorGetInfo) {
+      String keyScope,
+      String multiDeviceCredentialSupport,
+      AuthenticatorGetInfo authenticatorGetInfo,
+      String cxpConfigURL) {
     this.legalHeader = legalHeader;
     this.aaid = aaid;
     this.aaguid = aaguid;
     this.attestationCertificateKeyIdentifiers =
         CollectionUtil.immutableSetOrEmpty(attestationCertificateKeyIdentifiers);
+    this.friendlyNames = CollectionUtil.immutableMapOrEmpty(friendlyNames);
     this.description = description;
     this.alternativeDescriptions = alternativeDescriptions;
     this.authenticatorVersion = authenticatorVersion;
@@ -278,8 +343,14 @@ public class MetadataStatement {
     this.tcDisplayPNGCharacteristics = tcDisplayPNGCharacteristics;
     this.attestationRootCertificates = attestationRootCertificates;
     this.icon = icon;
+    this.iconDark = iconDark;
+    this.providerLogoLight = providerLogoLight;
+    this.providerLogoDark = providerLogoDark;
     this.supportedExtensions = supportedExtensions;
+    this.keyScope = keyScope;
+    this.multiDeviceCredentialSupport = multiDeviceCredentialSupport;
     this.authenticatorGetInfo = authenticatorGetInfo;
+    this.cxpConfigURL = cxpConfigURL;
   }
 
   /**
@@ -391,6 +462,36 @@ public class MetadataStatement {
   }
 
   /**
+   * @since 2.9.0
+   * @see <a
+   *     href="https://fidoalliance.org/specs/mds/fido-metadata-statement-v3.1-ps-20250521.html#dom-metadatastatement-icondark">FIDO
+   *     Metadata Statement</a>
+   */
+  public Optional<String> getIconDark() {
+    return Optional.ofNullable(this.iconDark);
+  }
+
+  /**
+   * @since 2.9.0
+   * @see <a
+   *     href="https://fidoalliance.org/specs/mds/fido-metadata-statement-v3.1-ps-20250521.html#dom-metadatastatement-providerlogolight">FIDO
+   *     Metadata Statement</a>
+   */
+  public Optional<String> getProviderLogoLight() {
+    return Optional.ofNullable(this.providerLogoLight);
+  }
+
+  /**
+   * @since 2.9.0
+   * @see <a
+   *     href="https://fidoalliance.org/specs/mds/fido-metadata-statement-v3.1-ps-20250521.html#dom-metadatastatement-providerlogodark">FIDO
+   *     Metadata Statement</a>
+   */
+  public Optional<String> getProviderLogoDark() {
+    return Optional.ofNullable(this.providerLogoDark);
+  }
+
+  /**
    * @see <a
    *     href="https://fidoalliance.org/specs/mds/fido-metadata-statement-v3.0-ps-20210518.html#metadata-statement-format">FIDO
    *     Metadata Statement</a>
@@ -400,11 +501,41 @@ public class MetadataStatement {
   }
 
   /**
+   * @since 2.9.0
+   * @see <a
+   *     href="https://fidoalliance.org/specs/mds/fido-metadata-statement-v3.1-ps-20250521.html#dom-metadatastatement-keyscope">FIDO
+   *     Metadata Statement</a>
+   */
+  public Optional<String> getKeyScope() {
+    return Optional.ofNullable(this.keyScope);
+  }
+
+  /**
+   * @since 2.9.0
+   * @see <a
+   *     href="https://fidoalliance.org/specs/mds/fido-metadata-statement-v3.1-ps-20250521.html#dom-metadatastatement-multidevicecredentialsupport">FIDO
+   *     Metadata Statement</a>
+   */
+  public Optional<String> getMultiDeviceCredentialSupport() {
+    return Optional.ofNullable(this.multiDeviceCredentialSupport);
+  }
+
+  /**
    * @see <a
    *     href="https://fidoalliance.org/specs/mds/fido-metadata-statement-v3.0-ps-20210518.html#metadata-statement-format">FIDO
    *     Metadata Statement</a>
    */
   public Optional<AuthenticatorGetInfo> getAuthenticatorGetInfo() {
     return Optional.ofNullable(this.authenticatorGetInfo);
+  }
+
+  /**
+   * @since 2.9.0
+   * @see <a
+   *     href="https://fidoalliance.org/specs/mds/fido-metadata-statement-v3.1-ps-20250521.html#dom-metadatastatement-cxpconfigurl">FIDO
+   *     Metadata Statement</a>
+   */
+  public Optional<String> getCxpConfigURL() {
+    return Optional.ofNullable(this.cxpConfigURL);
   }
 }

--- a/webauthn-server-attestation/src/main/java/com/yubico/fido/metadata/ProtocolFamily.java
+++ b/webauthn-server-attestation/src/main/java/com/yubico/fido/metadata/ProtocolFamily.java
@@ -1,5 +1,6 @@
 package com.yubico.fido.metadata;
 
+import com.fasterxml.jackson.annotation.JsonEnumDefaultValue;
 import com.fasterxml.jackson.annotation.JsonValue;
 
 /**
@@ -10,6 +11,14 @@ import com.fasterxml.jackson.annotation.JsonValue;
  *     Metadata Statement §4. Metadata Keys</a>
  */
 public enum ProtocolFamily {
+
+  /**
+   * (NOT DEFINED IN SPEC) Placeholder for any unknown {@link ProtocolFamily} value.
+   *
+   * @since 2.9.0
+   */
+  @JsonEnumDefaultValue
+  UNKNOWN("UNKNOWN"),
 
   /**
    * @see <a

--- a/webauthn-server-attestation/src/main/java/com/yubico/fido/metadata/PublicKeyRepresentationFormat.java
+++ b/webauthn-server-attestation/src/main/java/com/yubico/fido/metadata/PublicKeyRepresentationFormat.java
@@ -1,5 +1,6 @@
 package com.yubico.fido.metadata;
 
+import com.fasterxml.jackson.annotation.JsonEnumDefaultValue;
 import com.fasterxml.jackson.annotation.JsonValue;
 
 /**
@@ -14,6 +15,14 @@ import com.fasterxml.jackson.annotation.JsonValue;
  *     Registry of Predefined Values §3.6.2 Public Key Representation Formats</a>
  */
 public enum PublicKeyRepresentationFormat {
+
+  /**
+   * (NOT DEFINED IN SPEC) Placeholder for any unknown {@link PublicKeyRepresentationFormat} value.
+   *
+   * @since 2.9.0
+   */
+  @JsonEnumDefaultValue
+  UNKNOWN(0, "UNKNOWN"),
 
   /**
    * @see <a

--- a/webauthn-server-attestation/src/main/java/com/yubico/fido/metadata/StatusReport.java
+++ b/webauthn-server-attestation/src/main/java/com/yubico/fido/metadata/StatusReport.java
@@ -4,13 +4,14 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.yubico.internal.util.CollectionUtil;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.security.cert.X509Certificate;
 import java.time.LocalDate;
+import java.util.List;
 import java.util.Optional;
 import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NonNull;
@@ -27,7 +28,6 @@ import lombok.extern.jackson.Jacksonized;
 @Value
 @Builder
 @Jacksonized
-@AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class StatusReport {
 
   /**
@@ -91,11 +91,72 @@ public class StatusReport {
   String certificationPolicyVersion;
 
   /**
+   * @since 2.9.0
+   * @see <a
+   *     href="https://fidoalliance.org/specs/mds/fido-metadata-service-v3.1-ps-20250521.html#sctn-stat-rep">FIDO
+   *     Metadata Service §3.1.3. StatusReport dictionary</a>
+   */
+  List<String> certificationProfiles;
+
+  /**
    * @see <a
    *     href="https://fidoalliance.org/specs/mds/fido-metadata-service-v3.0-ps-20210518.html#statusreport-dictionary">FIDO
    *     Metadata Service §3.1.3. StatusReport dictionary</a>
    */
   String certificationRequirementsVersion;
+
+  /**
+   * @since 2.9.0
+   * @see <a
+   *     href="https://fidoalliance.org/specs/mds/fido-metadata-service-v3.1-ps-20250521.html#sctn-stat-rep">FIDO
+   *     Metadata Service §3.1.3. StatusReport dictionary</a>
+   */
+  String sunsetDate;
+
+  /**
+   * @since 2.9.0
+   * @see <a
+   *     href="https://fidoalliance.org/specs/mds/fido-metadata-service-v3.1-ps-20250521.html#sctn-stat-rep">FIDO
+   *     Metadata Service §3.1.3. StatusReport dictionary</a>
+   */
+  Long fipsRevision;
+
+  /**
+   * @since 2.9.0
+   * @see <a
+   *     href="https://fidoalliance.org/specs/mds/fido-metadata-service-v3.1-ps-20250521.html#sctn-stat-rep">FIDO
+   *     Metadata Service §3.1.3. StatusReport dictionary</a>
+   */
+  Long fipsPhysicalSecurityLevel;
+
+  private StatusReport(
+      @NonNull AuthenticatorStatus status,
+      LocalDate effectiveDate,
+      Long authenticatorVersion,
+      X509Certificate certificate,
+      String url,
+      String certificationDescriptor,
+      String certificateNumber,
+      String certificationPolicyVersion,
+      List<String> certificationProfiles,
+      String certificationRequirementsVersion,
+      String sunsetDate,
+      Long fipsRevision,
+      Long fipsPhysicalSecurityLevel) {
+    this.status = status;
+    this.effectiveDate = effectiveDate;
+    this.authenticatorVersion = authenticatorVersion;
+    this.certificate = certificate;
+    this.url = url;
+    this.certificationDescriptor = certificationDescriptor;
+    this.certificateNumber = certificateNumber;
+    this.certificationPolicyVersion = certificationPolicyVersion;
+    this.certificationProfiles = CollectionUtil.immutableListOrEmpty(certificationProfiles);
+    this.certificationRequirementsVersion = certificationRequirementsVersion;
+    this.sunsetDate = sunsetDate;
+    this.fipsRevision = fipsRevision;
+    this.fipsPhysicalSecurityLevel = fipsPhysicalSecurityLevel;
+  }
 
   /**
    * @see <a
@@ -185,5 +246,35 @@ public class StatusReport {
    */
   public Optional<String> getCertificationRequirementsVersion() {
     return Optional.ofNullable(this.certificationRequirementsVersion);
+  }
+
+  /**
+   * @since 2.9.0
+   * @see <a
+   *     href="https://fidoalliance.org/specs/mds/fido-metadata-service-v3.1-ps-20250521.html#sctn-stat-rep">FIDO
+   *     Metadata Service §3.1.3. StatusReport dictionary</a>
+   */
+  public Optional<String> getSunsetDate() {
+    return Optional.ofNullable(this.sunsetDate);
+  }
+
+  /**
+   * @since 2.9.0
+   * @see <a
+   *     href="https://fidoalliance.org/specs/mds/fido-metadata-service-v3.1-ps-20250521.html#sctn-stat-rep">FIDO
+   *     Metadata Service §3.1.3. StatusReport dictionary</a>
+   */
+  public Optional<Long> getFipsRevision() {
+    return Optional.ofNullable(fipsRevision);
+  }
+
+  /**
+   * @since 2.9.0
+   * @see <a
+   *     href="https://fidoalliance.org/specs/mds/fido-metadata-service-v3.1-ps-20250521.html#sctn-stat-rep">FIDO
+   *     Metadata Service §3.1.3. StatusReport dictionary</a>
+   */
+  public Optional<Long> getFipsPhysicalSecurityLevel() {
+    return Optional.ofNullable(fipsPhysicalSecurityLevel);
   }
 }

--- a/webauthn-server-attestation/src/main/java/com/yubico/fido/metadata/TransactionConfirmationDisplayType.java
+++ b/webauthn-server-attestation/src/main/java/com/yubico/fido/metadata/TransactionConfirmationDisplayType.java
@@ -1,5 +1,6 @@
 package com.yubico.fido.metadata;
 
+import com.fasterxml.jackson.annotation.JsonEnumDefaultValue;
 import com.fasterxml.jackson.annotation.JsonValue;
 
 /**
@@ -17,6 +18,15 @@ import com.fasterxml.jackson.annotation.JsonValue;
  *     Registry of Predefined Values §3.5 Transaction Confirmation Display Types</a>
  */
 public enum TransactionConfirmationDisplayType {
+
+  /**
+   * (NOT DEFINED IN SPEC) Placeholder for any unknown {@link TransactionConfirmationDisplayType}
+   * value.
+   *
+   * @since 2.9.0
+   */
+  @JsonEnumDefaultValue
+  UNKNOWN(0, "UNKNOWN"),
 
   /**
    * @see <a

--- a/webauthn-server-attestation/src/test/scala/com/yubico/fido/metadata/Generators.scala
+++ b/webauthn-server-attestation/src/test/scala/com/yubico/fido/metadata/Generators.scala
@@ -265,12 +265,14 @@ object Generators {
     for {
       selfAttestedFRR <- arbitrary[Option[Double]]
       selfAttestedFAR <- arbitrary[Option[Double]]
+      iAPARThreshold <- arbitrary[Option[Double]]
       maxTemplates <- arbitrary[Option[Int]]
       maxRetries <- arbitrary[Option[Int]]
       blockSlowdown <- arbitrary[Option[Int]]
     } yield new BiometricAccuracyDescriptor(
       selfAttestedFRR.map(Double.box).orNull,
       selfAttestedFAR.map(Double.box).orNull,
+      iAPARThreshold.map(Double.box).orNull,
       maxTemplates.map(Integer.valueOf).orNull,
       maxRetries.map(Integer.valueOf).orNull,
       blockSlowdown.map(Integer.valueOf).orNull,

--- a/yubico-util/src/main/java/com/yubico/internal/util/CollectionUtil.java
+++ b/yubico-util/src/main/java/com/yubico/internal/util/CollectionUtil.java
@@ -21,6 +21,11 @@ public class CollectionUtil {
     return Collections.unmodifiableMap(new HashMap<>(m));
   }
 
+  /** Alias of <code>s == null ? Collections.emptyMap() : CollectionUtil.immutableMap(s)</code>. */
+  public static <K, V> Map<K, V> immutableMapOrEmpty(Map<K, V> s) {
+    return s == null ? Collections.emptyMap() : immutableMap(s);
+  }
+
   /**
    * Make an unmodifiable shallow copy of the argument.
    *


### PR DESCRIPTION
This is already released as [experimental release `2.9.0-alpha1`](https://github.com/Yubico/java-webauthn-server/releases/tag/2.9.0-alpha1) to unbreak people's deployments, but we'll review after the fact and iterate as needed.

This incorporates both PR #467 and #468, preserving the original commits from both PRs.

Beyond adding the missing `AttachmentHint` value identified in #466, this adds an `UNKNOWN` constant as the default deserialization of all enums in the MDS data model; this should prevent hard crashes on new enum values in the future. To ensure that new values don't go unnoticed forever, this also adds a new integration test that attempts to deserialize the BLOB with enum defaults disabled and unknown fields forbidden. This should help us detect when new additions appear in the upstream data, as the integration test runs [once a week on GitHub Actions](https://github.com/Yubico/java-webauthn-server/actions/workflows/integration-test.yml).

The new test also revealed several other new fields that were missing. I also added any other new fields defined in immediate proximity to the ones identified by the test; not all of these added fields have yet appeared in the actual data.

Fixes #466.