### PR TITLE
Fix integration test

### DIFF
--- a/webauthn-server-attestation/build.gradle.kts
+++ b/webauthn-server-attestation/build.gradle.kts
@@ -62,7 +62,7 @@ val integrationTest = task<Test>("integrationTest") {
   classpath = sourceSets["integrationTest"].runtimeClasspath
   shouldRunAfter(tasks.test)
   val mdsCacheDir = project.layout.buildDirectory.dir("fido-mds-cache").get().asFile
-  mdsCacheDir.mkdir()
+  mdsCacheDir.mkdirs()
   environment("FIDO_MDS_CACHE_DIR", mdsCacheDir.absolutePath)
 }
 tasks["check"].dependsOn(integrationTest)

--- a/webauthn-server-attestation/build.gradle.kts
+++ b/webauthn-server-attestation/build.gradle.kts
@@ -64,6 +64,7 @@ val integrationTest = task<Test>("integrationTest") {
   val mdsCacheDir = project.layout.buildDirectory.dir("fido-mds-cache").get().asFile
   mdsCacheDir.mkdirs()
   environment("FIDO_MDS_CACHE_DIR", mdsCacheDir.absolutePath)
+  inputs.dir(mdsCacheDir)
 }
 tasks["check"].dependsOn(integrationTest)
 

--- a/webauthn-server-attestation/src/integrationTest/scala/com/yubico/fido/metadata/FidoMetadataDownloaderIntegrationTest.scala
+++ b/webauthn-server-attestation/src/integrationTest/scala/com/yubico/fido/metadata/FidoMetadataDownloaderIntegrationTest.scala
@@ -13,8 +13,6 @@ import org.scalatest.tags.Slow
 import org.scalatestplus.junit.JUnitRunner
 
 import scala.jdk.CollectionConverters.ListHasAsScala
-import scala.util.Success
-import scala.util.Try
 
 @Slow
 @Network
@@ -28,16 +26,15 @@ class FidoMetadataDownloaderIntegrationTest
     val downloader = cachedDefaultSettingsDownloader.build()
 
     it("downloads and verifies the root cert and BLOB successfully.") {
-      val blob = Try(TestCaches.cacheSynchronized(downloader.loadCachedBlob))
-      blob shouldBe a[Success[_]]
-      blob.get should not be null
+      val blob = TestCaches.cacheSynchronized(downloader.loadCachedBlob)
+      blob should not be null
     }
 
     it(
       "does not encounter any CRLDistributionPoints entries in unknown format."
     ) {
-      val blob = Try(TestCaches.cacheSynchronized(downloader.loadCachedBlob))
-      blob shouldBe a[Success[_]]
+      val blob = TestCaches.cacheSynchronized(downloader.loadCachedBlob)
+      blob should not be null
       val trustRootCert =
         CertificateParser.parseDer(
           TestCaches.trustRootCache.get.getBytes
@@ -86,9 +83,8 @@ class FidoMetadataDownloaderIntegrationTest
       .build()
 
     it("downloads and parses the BLOB successfully.") {
-      val blob = Try(TestCaches.cacheSynchronized(downloader.loadCachedBlob))
-      blob shouldBe a[Success[_]]
-      blob.get should not be null
+      val blob = TestCaches.cacheSynchronized(downloader.loadCachedBlob)
+      blob should not be null
     }
   }
 


### PR DESCRIPTION
The [integration test workflow](https://github.com/Yubico/java-webauthn-server/actions/workflows/integration-test.yml) is [currently failing](https://github.com/Yubico/java-webauthn-server/actions/runs/25739992637). This turns out to be because the [`integrationTest` task configuration does not recursively create missing parent directories](https://github.com/Yubico/java-webauthn-server/commit/a81cbabea7530e1da68caf0e696629c445202616).