### PR TITLE
Improve flaky tests

### DIFF
--- a/webauthn-server-attestation/build.gradle.kts
+++ b/webauthn-server-attestation/build.gradle.kts
@@ -45,13 +45,7 @@ dependencies {
   testImplementation("org.scalatest:scalatest_2.13")
   testImplementation("org.scalatestplus:junit-4-13_2.13")
   testImplementation("org.scalatestplus:scalacheck-1-16_2.13")
-
-  testImplementation("org.slf4j:slf4j-api") {
-    version {
-      strictly("[1.7.25,1.8-a)") // Pre-1.8 version required by slf4j-test
-    }
-  }
-  testRuntimeOnly("uk.org.lidalia:slf4j-test")
+  testImplementation("org.slf4j:slf4j-api")
 }
 
 val integrationTest = task<Test>("integrationTest") {

--- a/webauthn-server-core/src/test/scala/com/yubico/webauthn/RelyingPartyAssertionSpec.scala
+++ b/webauthn-server-core/src/test/scala/com/yubico/webauthn/RelyingPartyAssertionSpec.scala
@@ -1168,7 +1168,7 @@ class RelyingPartyAssertionSpec
                   genCredentialIdAndAllowCredentials,
                   genUsernameOrUserHandle,
                   genUserHandle,
-                  maxDiscardedFactor(20), // This helps the `whenever` clause below not make the test flaky
+                  maxDiscardedFactor(30), // This helps the `whenever` clause below not make the test flaky
                 ) {
                   case (
                         (credentialId, allowCredentials),

--- a/webauthn-server-core/src/test/scala/com/yubico/webauthn/RelyingPartyV2AssertionSpec.scala
+++ b/webauthn-server-core/src/test/scala/com/yubico/webauthn/RelyingPartyV2AssertionSpec.scala
@@ -1159,7 +1159,7 @@ class RelyingPartyV2AssertionSpec
                     genCredentialIdAndAllowCredentials,
                     genUserIdentifiers,
                     genUserHandle,
-                    maxDiscardedFactor(20), // This helps the `whenever` clause below not make the test flaky
+                    maxDiscardedFactor(30), // This helps the `whenever` clause below not make the test flaky
                   ) {
                     case (
                           (credentialId, allowCredentials),


### PR DESCRIPTION
- [Bump maxDiscardedFactor in RelyingParty[V2]AssertionSpec](https://github.com/Yubico/java-webauthn-server/commit/b036b86e09687914a68dde3b3572801f757b5492)

  We had a ["Gave up after 9 successful property evaluations" failure](https://github.com/Yubico/java-webauthn-server/runs/76739494923) on GitHub actions, so a factor 20 seems to be _just_ a bit too restrictive.
- [Drop slf4j-test from webauthn-server-attestation test dependencies](https://github.com/Yubico/java-webauthn-server/commit/6fbc56e1e14152ad32fe75c1ca66df4128bf75d6)

  This was originally done in commit https://github.com/Yubico/java-webauthn-server/commit/cdf95131266e9d89bed3df9c52644b06306e1cea and then undone for no apparent reason in https://github.com/Yubico/java-webauthn-server/commit/efa4b009d88c3788fa19acdae407a816aeb6746a. The tests added in https://github.com/Yubico/java-webauthn-server/commit/efa4b009d88c3788fa19acdae407a816aeb6746a do not use any of the features of `slf4j-test`; it appears the dependency was re-added solely for capturing log output.
