### PR TITLE
Make TestAuthenticator.createAuthenticatorData harder to call incorrectly

### DIFF
--- a/webauthn-server-core/build.gradle.kts
+++ b/webauthn-server-core/build.gradle.kts
@@ -66,3 +66,13 @@ tasks.withType(Jar::class) {
     ))
   }
 }
+
+tasks.register<JavaExec>("regenerateTestData") {
+  classpath = sourceSets.test.get().runtimeClasspath
+  mainClass = "com.yubico.webauthn.RegistrationTestDataGenerator"
+  description = "Generate code to paste into RegistrationTestData.scala"
+  group = "development"
+  javaLauncher.set(javaToolchains.launcherFor {
+    languageVersion.set(JavaLanguageVersion.of(25))
+  })
+}

--- a/webauthn-server-core/src/test/scala/com/yubico/webauthn/RegistrationTestData.scala
+++ b/webauthn-server-core/src/test/scala/com/yubico/webauthn/RegistrationTestData.scala
@@ -72,6 +72,7 @@ import java.security.spec.PKCS8EncodedKeySpec
 import scala.jdk.CollectionConverters._
 import scala.jdk.OptionConverters.RichOption
 
+/** Run using IDE or `./gradlew regenerateTestData` */
 object RegistrationTestDataGenerator extends App {
   regenerateTestData()
 

--- a/webauthn-server-core/src/test/scala/com/yubico/webauthn/RegistrationTestData.scala
+++ b/webauthn-server-core/src/test/scala/com/yubico/webauthn/RegistrationTestData.scala
@@ -59,6 +59,9 @@ import org.bouncycastle.asn1.x500.X500Name
 import org.bouncycastle.asn1.x509.Extension
 import org.bouncycastle.asn1.x509.GeneralName
 import org.bouncycastle.asn1.x509.GeneralNamesBuilder
+import org.junit.runner.RunWith
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatestplus.junit.JUnitRunner
 
 import java.nio.charset.StandardCharsets
 import java.security.KeyFactory
@@ -168,7 +171,7 @@ object RegistrationTestDataGenerator extends App {
           printTestDataCode(newTestData)
         case Failure(e) =>
           println("Failed to regenerate")
-          e.printStackTrace()
+          throw e;
       }
     }
   }
@@ -1441,5 +1444,16 @@ case class AssertionTestData(
         request.getPublicKeyCredentialRequestOptions,
       )
     )
+  }
+}
+
+@RunWith(classOf[JUnitRunner])
+class RegistrationTestDataSpec extends AnyFunSpec {
+  describe("RegistrationTestDataGenerator") {
+    it("successfully regenerates all test cases.") {
+      assume(Util.eddsaAvailable)
+      assume(Util.mldsaAvailable)
+      RegistrationTestDataGenerator.regenerateTestData()
+    }
   }
 }

--- a/webauthn-server-core/src/test/scala/com/yubico/webauthn/RegistrationTestData.scala
+++ b/webauthn-server-core/src/test/scala/com/yubico/webauthn/RegistrationTestData.scala
@@ -71,9 +71,6 @@ import java.security.cert.X509Certificate
 import java.security.spec.PKCS8EncodedKeySpec
 import scala.jdk.CollectionConverters._
 import scala.jdk.OptionConverters.RichOption
-import scala.util.Failure
-import scala.util.Success
-import scala.util.Try
 
 object RegistrationTestDataGenerator extends App {
   regenerateTestData()
@@ -165,14 +162,8 @@ object RegistrationTestDataGenerator extends App {
         td.Tpm.ValidRs1,
       ).zipWithIndex
     } {
-      testData.regenerateFull() match {
-        case Success(newTestData) =>
-          println(i)
-          printTestDataCode(newTestData)
-        case Failure(e) =>
-          println("Failed to regenerate")
-          throw e;
-      }
+      println(i)
+      printTestDataCode(testData.regenerateFull())
     }
   }
 }
@@ -1255,15 +1246,14 @@ case class RegistrationTestData(
       KeyPair,
       List[(X509Certificate, PrivateKey)],
   ) = ???
-  def regenerateFull(): Try[RegistrationTestData] =
-    Try({
-      val (credential, keypair, attestationCertChain) = regenerate()
-      val newValue =
-        RegistrationTestData.from(credential, keypair, attestationCertChain)
-      newValue.copy(
-        assertion = assertion.map(_.regenerate(newValue))
-      )
-    })
+  def regenerateFull(): RegistrationTestData = {
+    val (credential, keypair, attestationCertChain) = regenerate()
+    val newValue =
+      RegistrationTestData.from(credential, keypair, attestationCertChain)
+    newValue.copy(
+      assertion = assertion.map(_.regenerate(newValue))
+    )
+  }
 
   protected def validate(): Unit = {
     val alg = COSEAlgorithmIdentifier

--- a/webauthn-server-core/src/test/scala/com/yubico/webauthn/RegistrationTestData.scala
+++ b/webauthn-server-core/src/test/scala/com/yubico/webauthn/RegistrationTestData.scala
@@ -440,7 +440,7 @@ object RegistrationTestData {
     ) {
       override def regenerate() =
         TestAuthenticator.createBasicAttestedCredential(
-          keyAlgorithm = COSEAlgorithmIdentifier.EdDSA,
+          keyAlgorithm = Some(COSEAlgorithmIdentifier.EdDSA),
           attestationMaker = AttestationMaker.packed(
             AttestationSigner.selfsigned(COSEAlgorithmIdentifier.ES256)
           ),
@@ -477,7 +477,7 @@ object RegistrationTestData {
     ) {
       override def regenerate() =
         TestAuthenticator.createBasicAttestedCredential(
-          keyAlgorithm = COSEAlgorithmIdentifier.Ed448,
+          keyAlgorithm = Some(COSEAlgorithmIdentifier.Ed448),
           attestationMaker = AttestationMaker.packed(
             AttestationSigner.selfsigned(COSEAlgorithmIdentifier.ES256)
           ),
@@ -515,7 +515,7 @@ object RegistrationTestData {
     ) {
       override def regenerate() =
         TestAuthenticator.createBasicAttestedCredential(
-          keyAlgorithm = COSEAlgorithmIdentifier.ML_DSA_44,
+          keyAlgorithm = Some(COSEAlgorithmIdentifier.ML_DSA_44),
           attestationMaker = AttestationMaker.packed(
             AttestationSigner.selfsigned(COSEAlgorithmIdentifier.ML_DSA_44)
           ),
@@ -553,7 +553,7 @@ object RegistrationTestData {
     ) {
       override def regenerate() =
         TestAuthenticator.createBasicAttestedCredential(
-          keyAlgorithm = COSEAlgorithmIdentifier.ML_DSA_65,
+          keyAlgorithm = Some(COSEAlgorithmIdentifier.ML_DSA_65),
           attestationMaker = AttestationMaker.packed(
             AttestationSigner.selfsigned(COSEAlgorithmIdentifier.ML_DSA_65)
           ),
@@ -591,7 +591,7 @@ object RegistrationTestData {
     ) {
       override def regenerate() =
         TestAuthenticator.createBasicAttestedCredential(
-          keyAlgorithm = COSEAlgorithmIdentifier.ML_DSA_87,
+          keyAlgorithm = Some(COSEAlgorithmIdentifier.ML_DSA_87),
           attestationMaker = AttestationMaker.packed(
             AttestationSigner.selfsigned(COSEAlgorithmIdentifier.ML_DSA_87)
           ),
@@ -616,7 +616,7 @@ object RegistrationTestData {
     ) {
       override def regenerate() =
         TestAuthenticator.createBasicAttestedCredential(
-          keyAlgorithm = COSEAlgorithmIdentifier.RS256,
+          keyAlgorithm = Some(COSEAlgorithmIdentifier.RS256),
           attestationMaker = AttestationMaker.packed(
             AttestationSigner.selfsigned(COSEAlgorithmIdentifier.RS256)
           ),
@@ -641,7 +641,7 @@ object RegistrationTestData {
     ) {
       override def regenerate() =
         TestAuthenticator.createBasicAttestedCredential(
-          keyAlgorithm = COSEAlgorithmIdentifier.RS384,
+          keyAlgorithm = Some(COSEAlgorithmIdentifier.RS384),
           attestationMaker = AttestationMaker.packed(
             AttestationSigner.selfsigned(COSEAlgorithmIdentifier.RS384)
           ),
@@ -666,7 +666,7 @@ object RegistrationTestData {
     ) {
       override def regenerate() =
         TestAuthenticator.createBasicAttestedCredential(
-          keyAlgorithm = COSEAlgorithmIdentifier.RS512,
+          keyAlgorithm = Some(COSEAlgorithmIdentifier.RS512),
           attestationMaker = AttestationMaker.packed(
             AttestationSigner.selfsigned(COSEAlgorithmIdentifier.RS512)
           ),
@@ -703,7 +703,7 @@ object RegistrationTestData {
     ) {
       override def regenerate() =
         TestAuthenticator.createBasicAttestedCredential(
-          keyAlgorithm = COSEAlgorithmIdentifier.RS1,
+          keyAlgorithm = Some(COSEAlgorithmIdentifier.RS1),
           attestationMaker = AttestationMaker.packed(
             AttestationSigner.selfsigned(COSEAlgorithmIdentifier.RS1)
           ),
@@ -947,7 +947,7 @@ object RegistrationTestData {
     ) {
       override def regenerate() =
         TestAuthenticator.createBasicAttestedCredential(
-          keyAlgorithm = COSEAlgorithmIdentifier.ES256,
+          keyAlgorithm = Some(COSEAlgorithmIdentifier.ES256),
           attestationMaker = AttestationMaker.tpm(
             AttestationSigner.ca(
               alg = COSEAlgorithmIdentifier.ES256,
@@ -980,7 +980,7 @@ object RegistrationTestData {
     ) {
       override def regenerate() =
         TestAuthenticator.createBasicAttestedCredential(
-          keyAlgorithm = COSEAlgorithmIdentifier.ES256,
+          keyAlgorithm = Some(COSEAlgorithmIdentifier.ES256),
           attestationMaker = AttestationMaker.tpm(
             AttestationSigner.ca(
               alg = COSEAlgorithmIdentifier.ES256,
@@ -1013,7 +1013,7 @@ object RegistrationTestData {
     ) {
       override def regenerate() =
         TestAuthenticator.createBasicAttestedCredential(
-          keyAlgorithm = COSEAlgorithmIdentifier.ES384,
+          keyAlgorithm = Some(COSEAlgorithmIdentifier.ES384),
           attestationMaker = AttestationMaker.tpm(
             AttestationSigner.ca(
               alg = COSEAlgorithmIdentifier.ES384,
@@ -1046,7 +1046,7 @@ object RegistrationTestData {
     ) {
       override def regenerate() =
         TestAuthenticator.createBasicAttestedCredential(
-          keyAlgorithm = COSEAlgorithmIdentifier.ES512,
+          keyAlgorithm = Some(COSEAlgorithmIdentifier.ES512),
           attestationMaker = AttestationMaker.tpm(
             AttestationSigner.ca(
               alg = COSEAlgorithmIdentifier.ES512,
@@ -1080,7 +1080,7 @@ object RegistrationTestData {
     ) {
       override def regenerate() =
         TestAuthenticator.createBasicAttestedCredential(
-          keyAlgorithm = COSEAlgorithmIdentifier.RS256,
+          keyAlgorithm = Some(COSEAlgorithmIdentifier.RS256),
           attestationMaker = AttestationMaker.tpm(
             AttestationSigner.ca(
               alg = COSEAlgorithmIdentifier.RS256,
@@ -1114,7 +1114,7 @@ object RegistrationTestData {
     ) {
       override def regenerate() =
         TestAuthenticator.createBasicAttestedCredential(
-          keyAlgorithm = COSEAlgorithmIdentifier.RS384,
+          keyAlgorithm = Some(COSEAlgorithmIdentifier.RS384),
           attestationMaker = AttestationMaker.tpm(
             AttestationSigner.ca(
               alg = COSEAlgorithmIdentifier.RS384,
@@ -1148,7 +1148,7 @@ object RegistrationTestData {
     ) {
       override def regenerate() =
         TestAuthenticator.createBasicAttestedCredential(
-          keyAlgorithm = COSEAlgorithmIdentifier.RS512,
+          keyAlgorithm = Some(COSEAlgorithmIdentifier.RS512),
           attestationMaker = AttestationMaker.tpm(
             AttestationSigner.ca(
               alg = COSEAlgorithmIdentifier.RS512,
@@ -1182,7 +1182,7 @@ object RegistrationTestData {
     ) {
       override def regenerate() =
         TestAuthenticator.createBasicAttestedCredential(
-          keyAlgorithm = COSEAlgorithmIdentifier.RS1,
+          keyAlgorithm = Some(COSEAlgorithmIdentifier.RS1),
           attestationMaker = AttestationMaker.tpm(
             AttestationSigner.ca(
               alg = COSEAlgorithmIdentifier.RS1,

--- a/webauthn-server-core/src/test/scala/com/yubico/webauthn/RelyingPartyRegistrationSpec.scala
+++ b/webauthn-server-core/src/test/scala/com/yubico/webauthn/RelyingPartyRegistrationSpec.scala
@@ -2363,7 +2363,7 @@ class RelyingPartyRegistrationSpec
                           credKeyAlgorithm
                         )
                       ),
-                      keyAlgorithm = credKeyAlgorithm,
+                      keyAlgorithm = Some(credKeyAlgorithm),
                     )
                   )
 
@@ -2537,7 +2537,7 @@ class RelyingPartyRegistrationSpec
                 it("Fails when EC key has an inverted Y coordinate.") {
                   val (authData, keypair) =
                     TestAuthenticator.createAuthenticatorData(keyAlgorithm =
-                      COSEAlgorithmIdentifier.ES256
+                      Some(COSEAlgorithmIdentifier.ES256)
                     )
 
                   val cose = CBORObject.DecodeFromBytes(
@@ -2576,7 +2576,7 @@ class RelyingPartyRegistrationSpec
                 it("Fails when RSA key is unrelated.") {
                   val (authData, keypair) =
                     TestAuthenticator.createAuthenticatorData(keyAlgorithm =
-                      COSEAlgorithmIdentifier.RS256
+                      Some(COSEAlgorithmIdentifier.RS256)
                     )
                   val testData = (RegistrationTestData.from _).tupled(
                     makeCred(
@@ -2856,7 +2856,7 @@ class RelyingPartyRegistrationSpec
                   ) {
                     val testData = (RegistrationTestData.from _).tupled(
                       TestAuthenticator.createBasicAttestedCredential(
-                        keyAlgorithm = COSEAlgorithmIdentifier.ES256,
+                        keyAlgorithm = Some(COSEAlgorithmIdentifier.ES256),
                         attestationMaker = AttestationMaker.tpm(
                           AttestationSigner.selfsigned(
                             alg = COSEAlgorithmIdentifier.ES256,

--- a/webauthn-server-core/src/test/scala/com/yubico/webauthn/RelyingPartyV2RegistrationSpec.scala
+++ b/webauthn-server-core/src/test/scala/com/yubico/webauthn/RelyingPartyV2RegistrationSpec.scala
@@ -2314,7 +2314,7 @@ class RelyingPartyV2RegistrationSpec
                           credKeyAlgorithm
                         )
                       ),
-                      keyAlgorithm = credKeyAlgorithm,
+                      keyAlgorithm = Some(credKeyAlgorithm),
                     )
                   )
 
@@ -2488,7 +2488,7 @@ class RelyingPartyV2RegistrationSpec
                 it("Fails when EC key has an inverted Y coordinate.") {
                   val (authData, keypair) =
                     TestAuthenticator.createAuthenticatorData(keyAlgorithm =
-                      COSEAlgorithmIdentifier.ES256
+                      Some(COSEAlgorithmIdentifier.ES256)
                     )
 
                   val cose = CBORObject.DecodeFromBytes(
@@ -2527,7 +2527,7 @@ class RelyingPartyV2RegistrationSpec
                 it("Fails when RSA key is unrelated.") {
                   val (authData, keypair) =
                     TestAuthenticator.createAuthenticatorData(keyAlgorithm =
-                      COSEAlgorithmIdentifier.RS256
+                      Some(COSEAlgorithmIdentifier.RS256)
                     )
                   val testData = (RegistrationTestData.from _).tupled(
                     makeCred(
@@ -2807,7 +2807,7 @@ class RelyingPartyV2RegistrationSpec
                   ) {
                     val testData = (RegistrationTestData.from _).tupled(
                       TestAuthenticator.createBasicAttestedCredential(
-                        keyAlgorithm = COSEAlgorithmIdentifier.ES256,
+                        keyAlgorithm = Some(COSEAlgorithmIdentifier.ES256),
                         attestationMaker = AttestationMaker.tpm(
                           AttestationSigner.selfsigned(
                             alg = COSEAlgorithmIdentifier.ES256,

--- a/webauthn-server-core/src/test/scala/com/yubico/webauthn/TestAuthenticator.scala
+++ b/webauthn-server-core/src/test/scala/com/yubico/webauthn/TestAuthenticator.scala
@@ -404,21 +404,25 @@ object TestAuthenticator {
       aaguid: ByteArray = Defaults.aaguid,
       authenticatorExtensions: Option[JsonNode] = None,
       credentialKeypair: Option[KeyPair] = None,
-      keyAlgorithm: COSEAlgorithmIdentifier = Defaults.keyAlgorithm,
+      keyAlgorithm: Option[COSEAlgorithmIdentifier] = None,
       flags: Option[AuthenticatorDataFlags] = None,
   ): (
       ByteArray,
       KeyPair,
   ) = {
     val keypair =
-      credentialKeypair.getOrElse(generateKeypair(algorithm = keyAlgorithm))
+      credentialKeypair.getOrElse(
+        generateKeypair(algorithm =
+          keyAlgorithm.getOrElse(Defaults.keyAlgorithm)
+        )
+      )
     val publicKeyCose = keypair.getPublic match {
       case pub: ECPublicKey      => WebAuthnTestCodecs.ecPublicKeyToCose(pub)
       case pub: BCEdDSAPublicKey => WebAuthnTestCodecs.eddsaPublicKeyToCose(pub)
       case pub: RSAPublicKey =>
-        WebAuthnTestCodecs.rsaPublicKeyToCose(pub, keyAlgorithm)
+        WebAuthnTestCodecs.rsaPublicKeyToCose(pub, keyAlgorithm.get)
       case pub if pub.getAlgorithm == "ML-DSA" =>
-        WebAuthnTestCodecs.mlDsaPublicKeyToCose(pub, keyAlgorithm)
+        WebAuthnTestCodecs.mlDsaPublicKeyToCose(pub, keyAlgorithm.get)
     }
 
     val authDataBytes: ByteArray = makeAuthDataBytes(
@@ -516,7 +520,7 @@ object TestAuthenticator {
   def createBasicAttestedCredential(
       aaguid: ByteArray = Defaults.aaguid,
       attestationMaker: AttestationMaker,
-      keyAlgorithm: COSEAlgorithmIdentifier = Defaults.keyAlgorithm,
+      keyAlgorithm: Option[COSEAlgorithmIdentifier] = None,
   ): (
       data.PublicKeyCredential[
         data.AuthenticatorAttestationResponse,
@@ -548,8 +552,9 @@ object TestAuthenticator {
       KeyPair,
       List[(X509Certificate, PrivateKey)],
   ) = {
-    val (authData, keypair) = createAuthenticatorData(credentialKeypair =
-      Some(generateKeypair(keyAlgorithm))
+    val (authData, keypair) = createAuthenticatorData(
+      credentialKeypair = Some(generateKeypair(keyAlgorithm)),
+      keyAlgorithm = Some(keyAlgorithm),
     )
     val signer = SelfAttestation(keypair, keyAlgorithm)
     createCredential(


### PR DESCRIPTION
This makes it harder to call `TestAuthenticator.createAuthenticatorData` with an incorrect combination of `credentialKeypair` and `keyAlgorithm`. Previously `keyAlgorithm` would default to ES256 regardless of the `credentialKeypair` type, which for example fails if `credentialKeypair` is an RSA key and `keyAlgorithm` is not set to an RSA algorithm. This would cause the function to "successfully" return an incorrect result. Now it will instead throw an exception if `keyAlgorithm` is required but not provided.

In particular, case index 19 (`Packed.SelfAttestationRs1`) in `RegistrationTestDataGenerator` fails before this change because the regeneration incorrectly passes ES256 (the default) as the `keyAlgorithm` to `TestAuthenticator.createAuthenticatorData` even though the `credentialKeypair` argument is an RSA key pair.