### PR TITLE
Add Gradle meta-task testJavaAll

### DIFF
--- a/buildSrc/src/main/kotlin/project-convention-java.gradle.kts
+++ b/buildSrc/src/main/kotlin/project-convention-java.gradle.kts
@@ -15,13 +15,17 @@ tasks.withType(JavaCompile::class) {
     }
 }
 
+tasks.register("testJavaAll") {
+  tasks["check"].dependsOn(this)
+}
+
 tasks.register<Test>("testJava8") {
   testClassesDirs = tasks.named<Test>("test").get().testClassesDirs
   classpath = tasks.named<Test>("test").get().classpath
   javaLauncher.set(javaToolchains.launcherFor {
     languageVersion.set(JavaLanguageVersion.of(8))
   })
-  tasks["check"].dependsOn(this)
+  tasks["testJavaAll"].dependsOn(this)
 }
 
 tasks.register<Test>("testJava11") {
@@ -30,7 +34,7 @@ tasks.register<Test>("testJava11") {
   javaLauncher.set(javaToolchains.launcherFor {
     languageVersion.set(JavaLanguageVersion.of(11))
   })
-  tasks["check"].dependsOn(this)
+  tasks["testJavaAll"].dependsOn(this)
 }
 
 tasks.register<Test>("testJava17") {
@@ -39,7 +43,7 @@ tasks.register<Test>("testJava17") {
   javaLauncher.set(javaToolchains.launcherFor {
     languageVersion.set(JavaLanguageVersion.of(17))
   })
-  tasks["check"].dependsOn(this)
+  tasks["testJavaAll"].dependsOn(this)
 }
 
 tasks.register<Test>("testJava21") {
@@ -48,7 +52,7 @@ tasks.register<Test>("testJava21") {
   javaLauncher.set(javaToolchains.launcherFor {
     languageVersion.set(JavaLanguageVersion.of(21))
   })
-  tasks["check"].dependsOn(this)
+  tasks["testJavaAll"].dependsOn(this)
 }
 
 tasks.register<Test>("testJava25") {
@@ -57,5 +61,5 @@ tasks.register<Test>("testJava25") {
   javaLauncher.set(javaToolchains.launcherFor {
     languageVersion.set(JavaLanguageVersion.of(25))
   })
-  tasks["check"].dependsOn(this)
+  tasks["testJavaAll"].dependsOn(this)
 }


### PR DESCRIPTION
So one can run `./gradlew testJavaAll` to run the tests for all supported Java versions without having to either spell out all of them, or use `./gradlew check` which also runs integration tests and formatting checks.