### PR TITLE
Fix match inexhaustiveness warnings

### DIFF
--- a/webauthn-server-core/src/test/scala/com/yubico/webauthn/TestAuthenticator.scala
+++ b/webauthn-server-core/src/test/scala/com/yubico/webauthn/TestAuthenticator.scala
@@ -918,7 +918,9 @@ object TestAuthenticator {
         (TpmAlgHash.SHA512, TpmAlgAsym.RSA)
       case COSEAlgorithmIdentifier.RS1 => (TpmAlgHash.SHA1, TpmAlgAsym.RSA)
       case COSEAlgorithmIdentifier.EdDSA | COSEAlgorithmIdentifier.Ed25519 |
-          COSEAlgorithmIdentifier.Ed448 =>
+          COSEAlgorithmIdentifier.Ed448 | COSEAlgorithmIdentifier.ML_DSA_44 |
+          COSEAlgorithmIdentifier.ML_DSA_65 |
+          COSEAlgorithmIdentifier.ML_DSA_87 =>
         ???
     }
     val hashFunc = hashId match {
@@ -969,7 +971,10 @@ object TestAuthenticator {
                   COSEAlgorithmIdentifier.RS512 |
                   COSEAlgorithmIdentifier.EdDSA |
                   COSEAlgorithmIdentifier.Ed25519 |
-                  COSEAlgorithmIdentifier.Ed448 =>
+                  COSEAlgorithmIdentifier.Ed448 |
+                  COSEAlgorithmIdentifier.ML_DSA_44 |
+                  COSEAlgorithmIdentifier.ML_DSA_65 |
+                  COSEAlgorithmIdentifier.ML_DSA_87 =>
                 ???
             }),
             // kdf_scheme: ??? (unused?)

--- a/webauthn-server-core/src/test/scala/com/yubico/webauthn/data/Generators.scala
+++ b/webauthn-server-core/src/test/scala/com/yubico/webauthn/data/Generators.scala
@@ -1038,6 +1038,7 @@ object Generators {
               evalByCredential.asJava,
               eval,
             )
+          case (None, None) => ??? // Impossible given Gen.oneOf above
         }
       implicit val arbitraryPrfAuthenticationInput
           : Arbitrary[PrfAuthenticationInput] = Arbitrary(authenticationInput)


### PR DESCRIPTION
Fixes these warnings:

```
[Warn] webauthn-server-core/src/test/scala/com/yubico/webauthn/TestAuthenticator.scala:911:29: match may not be exhaustive.
It would fail on the following inputs: ML_DSA_44, ML_DSA_65, ML_DSA_87
[Warn] webauthn-server-core/src/test/scala/com/yubico/webauthn/TestAuthenticator.scala:968:37: match may not be exhaustive.
It would fail on the following inputs: ML_DSA_44, ML_DSA_65, ML_DSA_87
[Warn] webauthn-server-core/src/test/scala/com/yubico/webauthn/data/Generators.scala:1032:17: match maynot be exhaustive.
It would fail on the following input: (None, None)
```