### PR TITLE
Bump gradle-pitest-plugin from 1.19.0-rc2 to 1.19.0

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -10,7 +10,7 @@ repositories {
 }
 
 dependencies {
-  implementation("info.solidsoft.gradle.pitest:gradle-pitest-plugin:1.19.0-rc.2")
+  implementation("info.solidsoft.gradle.pitest:gradle-pitest-plugin:1.19.0")
   implementation("io.freefair.gradle:lombok-plugin:9.2.0")
 
   // Spotless dropped Java 8 support in version 2.33.0


### PR DESCRIPTION
This fixes the errors below, which seem to be a case of the [`NoClassDefFoundError` regression][1] described in the [1.19.0-rc3 patch notes][2].

This appears to have been broken since merging commit e5e609584ae44fd0b86aeee45d767a4d57e3fd98.

[1]: https://github.com/szpak/gradle-pitest-plugin/issues/385
[2]: https://github.com/szpak/gradle-pitest-plugin/blob/master/CHANGELOG.md#1190-rc3---2026-01-19

```
> Task :webauthn-server-attestation:pitest
4:23:03 PM PIT >> INFO : Verbose logging is disabled. If you encounter a problem, please enable it before reporting an issue.
4:23:03 PM PIT >> INFO : Created 71 mutation test units in pre scan
4:23:03 PM PIT >> INFO : Sending 357 test classes to minion
4:23:03 PM PIT >> INFO : Sent tests to minion
4:23:04 PM PIT >> INFO : MINION : RuntimeException while transforming  com/yubico/webauthn/RelyingPartyStartOperationSpec
4:23:04 PM PIT >> INFO : MINION : org.pitest.util.PitError: Could not find class definition for com/yubico/webauthn/RelyingPartyV2$RelyingPartyV2Builder
4:23:04 PM PIT >> INFO : MINION :
4:23:04 PM PIT >> INFO : MINION : Please copy and paste the information and the complete stacktrace below when reporting an issue
4:23:04 PM PIT >> INFO : MINION : VM : OpenJDK 64-Bit Server VM
4:23:04 PM PIT >> INFO : MINION : Vendor : Oracle Corporation
4:23:04 PM PIT >> INFO : MINION : Version : 25.0.4+7
4:23:04 PM PIT >> INFO : MINION : Uptime : 518
4:23:04 PM PIT >> INFO : MINION : Input ->
4:23:04 PM PIT >> INFO : MINION :  1 : -Dfile.encoding=UTF-8
4:23:04 PM PIT >> INFO : MINION :  2 : -Duser.country=US
4:23:04 PM PIT >> INFO : MINION :  3 : -Duser.language=en
4:23:04 PM PIT >> INFO : MINION :  4 : -Duser.variant
4:23:04 PM PIT >> INFO : MINION :  5 : -javaagent:/tmp/pitest-agent2467017034830247250.jar
4:23:04 PM PIT >> INFO : MINION :  6 : -ea
4:23:04 PM PIT >> INFO : MINION :  7 : -Djava.awt.headless=true
4:23:04 PM PIT >> INFO : MINION : BootClassPathSupported : false
4:23:04 PM PIT >> INFO : MINION :
4:23:04 PM PIT >> INFO : MINION : 	at org.pitest.classinfo.ComputeClassWriter.typeInfo(ComputeClassWriter.java:190)
[...]
4:23:04 PM PIT >> INFO : MINION : 	at org.pitest.coverage.execute.CoverageMinion.main(CoverageMinion.java:82)
4:23:04 PM PIT >> INFO : MINION : RuntimeException while transforming  com/yubico/webauthn/data/Generators$Extensions$
4:23:04 PM PIT >> INFO : MINION : org.pitest.util.PitError: Could not find class definition for com/yubico/webauthn/data/RegistrationExtensionInputs$RegistrationExtensionInputsBuilder
4:23:04 PM PIT >> INFO : MINION :
4:23:04 PM PIT >> INFO : MINION : Please copy and paste the information and the complete stacktrace below when reporting an issue
4:23:04 PM PIT >> INFO : MINION : VM : OpenJDK 64-Bit Server VM
4:23:04 PM PIT >> INFO : MINION : Vendor : Oracle Corporation
4:23:04 PM PIT >> INFO : MINION : Version : 25.0.4+7
4:23:04 PM PIT >> INFO : MINION : Uptime : 778
4:23:04 PM PIT >> INFO : MINION : Input ->
4:23:04 PM PIT >> INFO : MINION :  1 : -Dfile.encoding=UTF-8
4:23:04 PM PIT >> INFO : MINION :  2 : -Duser.country=US
4:23:04 PM PIT >> INFO : MINION :  3 : -Duser.language=en
4:23:04 PM PIT >> INFO : MINION :  4 : -Duser.variant
4:23:04 PM PIT >> INFO : MINION :  5 : -javaagent:/tmp/pitest-agent2467017034830247250.jar
4:23:04 PM PIT >> INFO : MINION :  6 : -ea
4:23:04 PM PIT >> INFO : MINION :  7 : -Djava.awt.headless=true
4:23:04 PM PIT >> INFO : MINION : BootClassPathSupported : false
4:23:04 PM PIT >> INFO : MINION :
4:23:04 PM PIT >> INFO : MINION : 	at org.pitest.classinfo.ComputeClassWriter.typeInfo(ComputeClassWriter.java:190)
[...]
4:23:04 PM PIT >> INFO : MINION : 	at org.pitest.coverage.execute.CoverageMinion.main(CoverageMinion.java:82)
4:23:05 PM PIT >> SEVERE : Coverage generator Minion exited abnormally due to UNKNOWN_ERROR
Exception in thread "main" org.pitest.util.PitError: Coverage generation minion exited abnormally! (UNKNOWN_ERROR)

Please copy and paste the information and the complete stacktrace below when reporting an issue
VM : OpenJDK 64-Bit Server VM
Vendor : Oracle Corporation
Version : 25.0.4+7
Uptime : 2492
Input ->
 1 : -Dfile.encoding=UTF-8
 2 : -Duser.country=US
 3 : -Duser.language=en
 4 : -Duser.variant
BootClassPathSupported : false

Please copy and paste the information and the complete stacktrace below when reporting an issue
VM : OpenJDK 64-Bit Server VM
Vendor : Oracle Corporation
Version : 25.0.4+7
Uptime : 2496
Input ->
 1 : -Dfile.encoding=UTF-8
 2 : -Duser.country=US
 3 : -Duser.language=en
 4 : -Duser.variant
BootClassPathSupported : false

	at org.pitest.util.Unchecked.translateCheckedException(Unchecked.java:20)
[...]
	at org.pitest.mutationtest.commandline.MutationCoverageReport.main(MutationCoverageReport.java:45)
Caused by: org.pitest.util.PitError: Coverage generation minion exited abnormally! (UNKNOWN_ERROR)

Please copy and paste the information and the complete stacktrace below when reporting an issue
VM : OpenJDK 64-Bit Server VM
Vendor : Oracle Corporation
Version : 25.0.4+7
Uptime : 2492
Input ->
 1 : -Dfile.encoding=UTF-8
 2 : -Duser.country=US
 3 : -Duser.language=en
 4 : -Duser.variant
BootClassPathSupported : false

	at org.pitest.coverage.execute.DefaultCoverageGenerator.gatherCoverageData(DefaultCoverageGenerator.java:167)
	at org.pitest.coverage.execute.DefaultCoverageGenerator.calculateCoverage(DefaultCoverageGenerator.java:108)
	... 7 more

> Task :webauthn-server-attestation:pitest FAILED
```