### PR TITLE
Filter README build status badge to main branch only

### DIFF
--- a/README
+++ b/README
@@ -6,7 +6,7 @@ java-webauthn-server
 :idprefix:
 :idseparator: -
 
-image:https://github.com/Yubico/java-webauthn-server/workflows/build/badge.svg["Build Status", link="https://github.com/Yubico/java-webauthn-server/actions"]
+image:https://github.com/Yubico/java-webauthn-server/actions/workflows/build.yml/badge.svg?branch=main["Build Status", link="https://github.com/Yubico/java-webauthn-server/actions/workflows/build.yml?query=branch%3Amain"]
 image:https://img.shields.io/endpoint?url=https%3A%2F%2FYubico.github.io%2Fjava-webauthn-server%2Fcoverage-badge.json["Mutation test coverage", link="https://Yubico.github.io/java-webauthn-server/"]
 image:https://github.com/Yubico/java-webauthn-server/actions/workflows/release-verify-signatures.yml/badge.svg["Binary reproducibility", link="https://github.com/Yubico/java-webauthn-server/actions/workflows/release-verify-signatures.yml"]
 


### PR DESCRIPTION
Occasionally the README build status badge shows "failing" just because the most recent build was on some other branch that's failing.