### PR TITLE
Retry MDS trust path validation with truncated x5c

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -16,6 +16,12 @@ Changes:
 
 * Default `FidoMetadataDownloader` trust root changed from GlobalSign R3 to R46.
   The default is used if using the builder method `useDefaultTrustRoot()`.
+* If `FidoMetadataDownloader` fails to validate the MDS trust path, it will now
+  retry the validation with the trust path truncated one certificate at a time.
+  This enables successfully validating metadata BLOBs with a cross-signed trust
+  root cert in the trust path during a transition grace period before MDS
+  migrates to a new trust root.
+  See: https://github.com/Yubico/java-webauthn-server/issues/498
 
 
 == Version 2.9.0 ==

--- a/webauthn-server-attestation/src/main/java/com/yubico/fido/metadata/FidoMetadataDownloader.java
+++ b/webauthn-server-attestation/src/main/java/com/yubico/fido/metadata/FidoMetadataDownloader.java
@@ -1271,7 +1271,6 @@ public final class FidoMetadataDownloader {
 
     final CertificateFactory certFactory = CertificateFactory.getInstance("X.509");
     final CertPathValidator cpv = CertPathValidator.getInstance("PKIX");
-    final CertPath blobCertPath = certFactory.generateCertPath(certChain);
     final PKIXParameters pathParams =
         new PKIXParameters(Collections.singleton(new TrustAnchor(trustRootCertificate, null)));
     if (certStore != null) {
@@ -1283,9 +1282,29 @@ public final class FidoMetadataDownloader {
     fetchCrlDistributionPoints(certChain, certFactory).ifPresent(pathParams::addCertStore);
 
     pathParams.setDate(Date.from(clock.instant()));
-    cpv.validate(blobCertPath, pathParams);
 
-    return parseResult.blob;
+    // Try validating first the full cert path, and if that fails retry by omitting one cert at a
+    // time from the end.
+    // This enables "short-circuiting" the cert path if the trust anchor appears in the cert path,
+    // as was the case in August 2026 when the new trust anchor "R46" appeared last in the cert path
+    // signed by the previous trust anchor "R3".
+    CertPathValidatorException firstError = null;
+    for (int pathLen = certChain.size(); pathLen >= 1; --pathLen) {
+      final CertPath blobCertPath = certFactory.generateCertPath(certChain.subList(0, pathLen));
+      try {
+        cpv.validate(blobCertPath, pathParams);
+        return parseResult.blob;
+      } catch (CertPathValidatorException e) {
+        if (firstError == null) {
+          firstError = e;
+        }
+        if (pathLen == 1) {
+          throw firstError;
+        }
+      }
+    }
+    throw new IllegalStateException(
+        "Exited without finding a certification path or failing to validate any certification path. This should be impossible, please file a bug report.");
   }
 
   ParseResult parseBlob(ByteArray jwt) throws IOException, Base64UrlException {

--- a/webauthn-server-attestation/src/test/scala/com/yubico/fido/metadata/FidoMetadataDownloaderSpec.scala
+++ b/webauthn-server-attestation/src/test/scala/com/yubico/fido/metadata/FidoMetadataDownloaderSpec.scala
@@ -43,6 +43,7 @@ import java.security.cert.CRL
 import java.security.cert.CertPathValidatorException
 import java.security.cert.CertPathValidatorException.BasicReason
 import java.security.cert.CertificateExpiredException
+import java.security.cert.PKIXReason
 import java.security.cert.X509Certificate
 import java.time.Clock
 import java.time.Instant
@@ -113,8 +114,9 @@ class FidoMetadataDownloaderSpec
       isCa: Boolean = false,
       name: String =
         "CN=Yubico java-webauthn-server unit tests blob cert, O=Yubico",
+      certKeypair: Option[KeyPair] = None,
   ): (X509Certificate, KeyPair, X500Name) = {
-    val keypair = TestAuthenticator.generateEcKeypair()
+    val keypair = certKeypair getOrElse TestAuthenticator.generateEcKeypair()
     val x500Name = new X500Name(name)
     (
       TestAuthenticator.buildCertificate(
@@ -2110,6 +2112,81 @@ class FidoMetadataDownloaderSpec
           ).getPayload
           blob should not be null
           blob.getNo should equal(blobNo)
+        }
+
+        it("A cross-signed trust root cert appearing in the cert path validates successfully.") {
+          val (unrelatedRootCert, unrelatedRootKeypair, unrelatedRootName) =
+            makeTrustRootCert(distinguishedName =
+              "CN=Yubico java-webauthn-server unit tests UNRELATED CA, O=Yubico"
+            )
+          val (oldRootCert, oldRootKeypair, oldRootName) =
+            makeTrustRootCert(distinguishedName =
+              "CN=Yubico java-webauthn-server unit tests OLD CA, O=Yubico"
+            )
+          val (newRootCert, newCaKeypair, newCaName) =
+            makeTrustRootCert(distinguishedName =
+              "CN=Yubico java-webauthn-server unit tests NEW CA, O=Yubico"
+            )
+          val (crossCert, _, _) = makeCert(
+            oldRootKeypair,
+            oldRootName,
+            name = newCaName.toString,
+            certKeypair = Some(newCaKeypair),
+            isCa = true,
+          )
+          val (blobCert, blobKeypair, _) = makeCert(newCaKeypair, newCaName)
+          val crls = List(
+            (oldRootName, oldRootKeypair),
+            (newCaName, newCaKeypair),
+            (unrelatedRootName, unrelatedRootKeypair),
+          ).map({
+            case (name, keypair) =>
+              TestAuthenticator.buildCrl(
+                name,
+                keypair.getPrivate,
+                "SHA256withECDSA",
+                CertValidFrom,
+                CertValidTo,
+              )
+          })
+
+          val blobJwt = makeBlob(
+            List(blobCert, crossCert),
+            blobKeypair,
+            LocalDate.parse("2022-01-19"),
+          )
+
+          for (trustRoot <- List(newRootCert, oldRootCert)) {
+            val blob = load(
+              FidoMetadataDownloader
+                .builder()
+                .expectLegalHeader(
+                  "Kom ihåg att du aldrig får snyta dig i mattan!"
+                )
+                .useTrustRoot(trustRoot)
+                .useBlob(blobJwt)
+                .clock(Clock.fixed(CertValidFrom, ZoneOffset.UTC))
+                .useCrls(crls.asJava)
+                .build()
+            )
+            blob should not be null
+          }
+
+          val thrown = the[CertPathValidatorException] thrownBy {
+            load(
+              FidoMetadataDownloader
+                .builder()
+                .expectLegalHeader(
+                  "Kom ihåg att du aldrig får snyta dig i mattan!"
+                )
+                .useTrustRoot(unrelatedRootCert)
+                .useBlob(blobJwt)
+                .clock(Clock.fixed(CertValidFrom, ZoneOffset.UTC))
+                .useCrls(crls.asJava)
+                .build()
+            )
+          }
+          thrown.getReason should be(PKIXReason.NO_TRUST_ANCHOR)
         }
       }
 


### PR DESCRIPTION
In August 2026, the FIDO Metadata Service (MDS) [updated the trust root certificate](https://fidoalliance.org/mds-changelog/) from GlobalSign R3 to R46. Soon after, the `x5c` JWT header was adjusted again to include the new R46 root cross-signed by the old R3 root. This `x5c` that includes the cross-signed R46 fails to validate with trust anchor R46, but validates successfully with trust anchor R3.

`CertPathValidator` implements RFC 5280, whose section 6 defines certification path _validation_, but not certification path _construction_. The validation algorithm only validates the particular cert path provided as input, but does not attempt to discover alternative certification paths.

The library constructs the cert path explicitly using `CertificateFactory.generateCertPath(List<Certificate>)` with the `x5c` array from the JWT header, which (currently) includes the trailing cross-signed R46 certificate and therefore fails path validation.

This change makes `FidoMetadataDownloader` retry the path validation with `x5c` truncated one cert at a time. This makes the `CertPathValidator` successfully validate the cross-signed MDS trust path in the 2nd iteration where the cross-signed R46 is omitted from the cert path.

An alternative solution is to use `CertPathBuilder` to _discover_ the cert path (with the intermediate certs from `x5c` provided as an untrusted `CertStore`) instead of taking `x5c` directly as the trust path. This has the drawback of introducing a new checked `CertPathBuilderException` into the public API. We can hide the `CertPathBuilderException` from the public API by wrapping it with `CertPathValidatorException`, but this effectively strips the `reason` value from the `CertPathValidatorException` that would have been thrown previously.

See also: https://github.com/Yubico/java-webauthn-server/issues/498